### PR TITLE
Fix PSA compilation; correct makefile dependencies

### DIFF
--- a/Makefile.ossl
+++ b/Makefile.ossl
@@ -14,24 +14,30 @@
 
 # ---- QCBOR location ----
 # This is for direct reference to QCBOR that is not installed in
-# /usr/local or some system location. The path names may need to be
+# /usr/local or some system location. The path may need to be
 # adjusted for your location of QCBOR.
-#QCBOR_INC= -I ../../QCBOR/master/inc
-#QCBOR_LIB=../../QCBOR/master/libqcbor.a
+#QCBOR_DIR=../../QCBOR/master
+#QCBOR_INC=-I $(QCBOR_DIR)/inc
+#QCBOR_LIB=$(QCBOR_DIR)/libqcbor.a
 
 # This is for reference to QCBOR that has been installed in
-# /usr/local/ or in some system location.
-QCBOR_INC= -I /usr/local/include
-QCBOR_LIB= -lqcbor
+# /usr/local/ or in some system location. This will typically
+# use dynamic linking if there is a libqcbor.so
+QCBOR_INC=-I /usr/local/include
+QCBOR_LIB=-lqcbor
 
 
 # ---- t_cose location ----
 # Adjust this to the location of t_cose in your build environment
-#T_COSE_INC= -I ../../t_cose/master/inc
-#T_COSE_LIB=../../t_cose/master/libt_cose.a
+#T_COSE_DIR=../../t_cose/master
+#T_COSE_INC= -I $(T_COSE_DIR)/inc
+#T_COSE_LIB=$(T_COSE_DIR)/libt_cose.a
 
-T_COSE_INC= -I /usr/local/include
-T_COSE_LIB= -lt_cose
+# This is for reference to QCBOR that has been installed in
+# /usr/local/ or in some system location. This will typically
+# use dynamic linking if there is a libqcbor.so
+T_COSE_INC=-I /usr/local/include
+T_COSE_LIB=-lt_cose
 
 
 # ---- crypto configuration -----
@@ -86,14 +92,15 @@ clean:
 
 
 # ---- public headers -----
-PUBLIC_INTERFACE=inc/ctoken_encode.h inc/ctoken_decode.h \
-                  inc/ctoken_cwt_labels.h 
+PUBLIC_INTERFACE=inc/ctoken.h inc/ctoken_encode.h inc/ctoken_decode.h \
+                  inc/ctoken_cwt_labels.h inc/ctoken_eat_labels.h \
+                  inc/ctoken_psaia_decode.h inc/ctoken_psaia_encode.h inc/ctoken_psaia_labels.h
 
 # ---- source dependecies -----
-src/ctoken_encode.o:	inc/ctoken_encode.h
-src/ctoken_decode.o:	inc/ctoken_decode.h 
-src/ctoken_psaia_encode.o:	inc/ctoken_psaia_encode.h inc/ctoken_psaia_labels.h  inc/ctoken_cwt_labels.h
-src/ctoken_psaia_decode.o:	inc/ctoken_psaia_decode.h inc/ctoken_psaia_labels.h  inc/ctoken_cwt_labels.h
+src/ctoken_encode.o:	inc/ctoken_encode.h inc/ctoken.h inc/ctoken_cwt_labels.h inc/ctoken_eat_labels.h
+src/ctoken_decode.o:	inc/ctoken_decode.h inc/ctoken.h inc/ctoken_cwt_labels.h inc/ctoken_eat_labels.h
+src/ctoken_psaia_encode.o:	inc/ctoken_psaia_encode.h inc/ctoken.h inc/ctoken_psaia_labels.h  inc/ctoken_cwt_labels.h inc/ctoken_eat_labels.h
+src/ctoken_psaia_decode.o:	inc/ctoken_psaia_decode.h inc/ctoken.h inc/ctoken_psaia_labels.h  inc/ctoken_cwt_labels.h inc/ctoken_eat_labels.h
 
 
 # ---- test dependencies -----
@@ -102,3 +109,4 @@ test/eat_test.o:	test/eat_test.h $(PUBLIC_INTERFACE)
 
 # ---- example dependencies ----
 eat_example_ossl.o:	$(PUBLIC_INTERFACE)
+

--- a/Makefile.psa
+++ b/Makefile.psa
@@ -12,30 +12,31 @@
 
 
 # ---- QCBOR location ----
-
 # This is for direct reference to QCBOR that is not installed in
-# /usr/local or some system location. The path names may need to be
+# /usr/local or some system location. The path may need to be
 # adjusted for your location of QCBOR.
-#QCBOR_INC= -I ../../QCBOR/master/inc
-#QCBOR_LIB=../../QCBOR/master/libqcbor.a
+#QCBOR_DIR=../../QCBOR/master
+#QCBOR_INC=-I $(QCBOR_DIR)/inc
+#QCBOR_LIB=$(QCBOR_DIR)/libqcbor.a
 
 # This is for reference to QCBOR that has been installed in
-# /usr/local/ or in some system location.
-QCBOR_INC= -I /usr/local/include
-QCBOR_LIB= -l qcbor
+# /usr/local/ or in some system location. This will typically
+# use dynamic linking if there is a libqcbor.so
+QCBOR_INC=-I /usr/local/include
+QCBOR_LIB=-lqcbor
+
 
 # ---- t_cose location ----
+# Adjust this to the location of t_cose in your build environment
+T_COSE_DIR=../../t_cose/master
+T_COSE_INC= -I $(T_COSE_DIR)/inc
+T_COSE_LIB=$(T_COSE_DIR)/libt_cose.a
 
-# This is for direct reference to t_cose that is not installed in
-# /usr/local or some system location. The path names may need to be
-# adjusted for your location of t_cose.
-#T_COSE_INC= -I ../../t_cose/master/inc
-#T_COSE_LIB=../../t_cose/master/libt_cose.a
-
-# This is for reference to t_cose that has been installed in
-# /usr/local/ or in some system location.
-T_COSE_INC= -I /usr/local/include
-T_COSE_LIB= -l t_cose
+# This is for reference to QCBOR that has been installed in
+# /usr/local/ or in some system location. This will typically
+# use dynamic linking if there is a libqcbor.so
+#T_COSE_INC=-I /usr/local/include
+#T_COSE_LIB=-lt_cose
 
 
 # ---- crypto configuration -----
@@ -65,7 +66,6 @@ ALL_INC=$(CRYPTO_INC) $(QCBOR_INC) $(T_COSE_INC) $(INC)
 CFLAGS=$(ALL_INC) $(C_OPTS) $(TEST_CONFIG_OPTS) $(CRYPTO_CONFIG_OPTS)
 
 SRC_OBJ=src/ctoken_encode.o src/ctoken_decode.o \
-        src/ctoken_eat_encode.o src/ctoken_eat_decode.o \
         src/ctoken_psaia_encode.o src/ctoken_psaia_decode.o
 
 
@@ -88,21 +88,20 @@ clean:
 
 
 # ---- public headers -----
-PUBLIC_INTERFACE=inc/ctoken_encode.h inc/ctoken_decode.h \
-                 inc/ctoken_cwt_labels.h 
+PUBLIC_INTERFACE=inc/ctoken.h inc/ctoken_encode.h inc/ctoken_decode.h \
+                  inc/ctoken_cwt_labels.h inc/ctoken_eat_labels.h \
+                  inc/ctoken_psaia_decode.h inc/ctoken_psaia_encode.h inc/ctoken_psaia_labels.h
 
 # ---- source dependecies -----
-src/ctoken_encode.o:	inc/ctoken_encode.h
-src/ctoken_decode.o:	inc/ctoken_decode.h 
-src/ctoken_eat_encode.o:	inc/ctoken_eat_encode.h
-src/ctoken_eat_decode.o:	inc/ctoken_eat_decode.h
-src/ctoken_psaia_encode.o:	inc/ctoken_psaia_encode.h inc/ctoken_psaia_labels.h inc/ctoken_eat_encode.h  inc/ctoken_cwt_labels.h
-src/ctoken_psaia_decode.o:	inc/ctoken_psaia_decode.h inc/ctoken_psaia_labels.h inc/ctoken_eat_decode.h  inc/ctoken_cwt_labels.h
+src/ctoken_encode.o:    inc/ctoken_encode.h inc/ctoken.h inc/ctoken_cwt_labels.h inc/ctoken_eat_labels.h
+src/ctoken_decode.o:    inc/ctoken_decode.h inc/ctoken.h inc/ctoken_cwt_labels.h inc/ctoken_eat_labels.h
+src/ctoken_psaia_encode.o:      inc/ctoken_psaia_encode.h inc/ctoken.h inc/ctoken_psaia_labels.h  inc/ctoken_cwt_labels.h inc/ctoken_eat_labels.h
+src/ctoken_psaia_decode.o:      inc/ctoken_psaia_decode.h inc/ctoken.h inc/ctoken_psaia_labels.h  inc/ctoken_cwt_labels.h inc/ctoken_eat_labels.h
 
 
 # ---- test dependencies -----
-test/cwt_test.o:	test/cwt_test.h $(PUBLIC_INTERFACE)
-test/eat_test.o:	test/eat_test.h $(PUBLIC_INTERFACE)
+test/cwt_test.o:        test/cwt_test.h $(PUBLIC_INTERFACE)
+test/eat_test.o:        test/eat_test.h $(PUBLIC_INTERFACE)
 
 # ---- example dependencies ----
-eat_example_psa.o:	$(PUBLIC_INTERFACE)
+eat_example_ossl.o:     $(PUBLIC_INTERFACE)

--- a/examples/eat_example_psa.c
+++ b/examples/eat_example_psa.c
@@ -26,8 +26,6 @@
 
 #include "ctoken_encode.h"
 #include "ctoken_decode.h"
-#include "ctoken_eat_encode.h"
-#include "ctoken_eat_decode.h"
 
 #include "t_cose/t_cose_common.h"
 #include "t_cose/t_cose_sign1_sign.h"
@@ -329,9 +327,9 @@ int32_t eat_encode(struct t_cose_key signing_key,
      * You can even make up your own claims.
      */
 
-    ctoken_eat_encode_nonce(&encode_ctx, nonce);
+    ctoken_encode_nonce(&encode_ctx, nonce);
 
-    ctoken_eat_encode_ueid(&encode_ctx, ueid);
+    ctoken_encode_ueid(&encode_ctx, ueid);
 
     /* Finally completed it. This invokes the signing and
      * ties everything off and outputs the completed token.
@@ -384,7 +382,7 @@ int32_t eat_decode(struct t_cose_key     verification_key,
     }
 
     /* Parse the nonce out of the token */
-    return_value = ctoken_eat_decode_nonce(&decode_context, nonce);
+    return_value = ctoken_decode_nonce(&decode_context, nonce);
 
 Done:
     return return_value;


### PR DESCRIPTION
Example code for PSA example was wrong.

Dependencies for makefiles weren't complete.