### PR TITLE
Revamp decode error handling

### DIFF
--- a/Makefile.psa
+++ b/Makefile.psa
@@ -55,7 +55,7 @@ C_OPTS=-Os -fPIC
 
 # ---- T_COSE Config and test options ----
 TEST_CONFIG_OPTS=
-TEST_OBJ=test/eat_test.o test/cwt_test.o test/psaia_test.o test/run_tests.o
+TEST_OBJ=test/eat_test.o test/cwt_test.o test/psa_test.o test/run_tests.o
 
 
 # ---- the main body that is invariant ----
@@ -64,7 +64,7 @@ ALL_INC=$(CRYPTO_INC) $(QCBOR_INC) $(T_COSE_INC) $(INC)
 CFLAGS=$(ALL_INC) $(C_OPTS) $(TEST_CONFIG_OPTS) $(CRYPTO_CONFIG_OPTS)
 
 SRC_OBJ=src/ctoken_encode.o src/ctoken_decode.o \
-        src/ctoken_psaia_encode.o src/ctoken_psaia_decode.o
+        src/ctoken_encode_psa.o src/ctoken_decode_psa.o
 
 
 all:	libctoken.a ctoken_test eat_example_psa
@@ -88,13 +88,13 @@ clean:
 # ---- public headers -----
 PUBLIC_INTERFACE=inc/ctoken/ctoken.h inc/ctoken/ctoken_encode.h inc/ctoken/ctoken_decode.h \
                   inc/ctoken/ctoken_cwt_labels.h inc/ctoken/ctoken_eat_labels.h \
-                  inc/ctoken/ctoken_psaia_decode.h inc/ctoken/ctoken_psaia_encode.h inc/ctoken/ctoken_psaia_labels.h
+                  inc/ctoken/ctoken_decode_psa.h inc/ctoken/ctoken_encode_psa.h inc/ctoken/ctoken_psa_labels.h
 
 # ---- source dependecies -----
 src/ctoken_encode.o:    inc/ctoken/ctoken_encode.h inc/ctoken/ctoken.h inc/ctoken/ctoken_cwt_labels.h inc/ctoken/ctoken_eat_labels.h
 src/ctoken_decode.o:    inc/ctoken/ctoken_decode.h inc/ctoken/ctoken.h inc/ctoken/ctoken_cwt_labels.h inc/ctoken/ctoken_eat_labels.h
-src/ctoken_psaia_encode.o:      inc/ctoken/ctoken_psaia_encode.h inc/ctoken/ctoken.h inc/ctoken/ctoken_psaia_labels.h  inc/ctoken/ctoken_cwt_labels.h inc/ctoken/ctoken_eat_labels.h
-src/ctoken_psaia_decode.o:      inc/ctoken/ctoken_psaia_decode.h inc/ctoken/ctoken.h inc/ctoken/ctoken_psaia_labels.h  inc/ctoken/ctoken_cwt_labels.h inc/ctoken/ctoken_eat_labels.h
+src/ctoken_psa_encode.o:      inc/ctoken/ctoken_psa_encode.h inc/ctoken/ctoken.h inc/ctoken/ctoken_psa_labels.h  inc/ctoken/ctoken_cwt_labels.h inc/ctoken/ctoken_eat_labels.h
+src/ctoken_psa_decode.o:      inc/ctoken/ctoken_psa_decode.h inc/ctoken/ctoken.h inc/ctoken/ctoken_psa_labels.h  inc/ctoken/ctoken_cwt_labels.h inc/ctoken/ctoken_eat_labels.h
 
 
 # ---- test dependencies -----

--- a/examples/eat_example_ossl.c
+++ b/examples/eat_example_ossl.c
@@ -350,7 +350,6 @@ int32_t eat_decode(struct t_cose_key     verification_key,
                    struct q_useful_buf_c token,
                    struct q_useful_buf_c *nonce)
 {
-    int return_value;
     struct ctoken_decode_ctx decode_context;
 
     /* Initialize the decoding context. No options are given.
@@ -369,16 +368,13 @@ int32_t eat_decode(struct t_cose_key     verification_key,
     ctoken_decode_set_verification_key(&decode_context, verification_key);
 
     /* Validate the signature on the token */
-    return_value = ctoken_decode_validate_token(&decode_context, token);
-    if(return_value) {
-        goto Done;
-    }
+    ctoken_decode_validate_token(&decode_context, token);
 
     /* Parse the nonce out of the token */
-    return_value = ctoken_decode_nonce(&decode_context, nonce);
+    ctoken_decode_nonce(&decode_context, nonce);
 
 Done:
-    return return_value;
+    return ctoken_decode_get_and_reset_error(&decode_context);
 }
 
 
@@ -469,7 +465,4 @@ int main(int argc, const char * argv[])
 
     eat_example();
 }
-
-
-// ((uint8_t *)completed_token.ptr)[59]++;
 

--- a/examples/eat_example_psa.c
+++ b/examples/eat_example_psa.c
@@ -364,7 +364,6 @@ int32_t eat_decode(struct t_cose_key     verification_key,
                    struct q_useful_buf_c token,
                    struct q_useful_buf_c *nonce)
 {
-    int return_value;
     struct ctoken_decode_ctx decode_context;
 
     /* Initialize the decoding context. No options are given.
@@ -383,16 +382,13 @@ int32_t eat_decode(struct t_cose_key     verification_key,
     ctoken_decode_set_verification_key(&decode_context, verification_key);
 
     /* Validate the signature on the token */
-    return_value = ctoken_decode_validate_token(&decode_context, token);
-    if(return_value) {
-        goto Done;
-    }
+    ctoken_decode_validate_token(&decode_context, token);
 
     /* Parse the nonce out of the token */
-    return_value = ctoken_decode_nonce(&decode_context, nonce);
+    ctoken_decode_nonce(&decode_context, nonce);
 
 Done:
-    return return_value;
+    return ctoken_decode_get_and_reset_error(&decode_context);
 }
 
 

--- a/inc/ctoken/ctoken_decode.h
+++ b/inc/ctoken/ctoken_decode.h
@@ -297,6 +297,7 @@ ctoken_decode_get_kid(struct ctoken_decode_ctx *context,
  * can be called and they will just return this error. The \c
  * ctoken_decode_get_xxx() functions will generally return 0 or
  * \c NULL if the token is in error.
+ * TODO: rewrite error handling
  *
  * It is thus possible to call ctoken_decode_validate_token()
  * and all the \c ctoken_decode_get_xxx() functions to parse the
@@ -308,7 +309,7 @@ ctoken_decode_get_kid(struct ctoken_decode_ctx *context,
  * token without signature verification because the info to look
  * up the verification key is the token, not the COSE key id.
  */
-enum ctoken_err_t
+void
 ctoken_decode_validate_token(struct ctoken_decode_ctx *context,
                              struct q_useful_buf_c     token);
 
@@ -1270,7 +1271,7 @@ ctoken_decode_profile(struct ctoken_decode_ctx *context,
  * other functions for getting claims so calls to this can be
  * intermixed with the other calls.
 */
-enum ctoken_err_t
+void
 ctoken_decode_next_claim(struct ctoken_decode_ctx   *context,
                          QCBORItem                  *claim);
 

--- a/inc/ctoken/ctoken_decode.h
+++ b/inc/ctoken/ctoken_decode.h
@@ -505,7 +505,7 @@ ctoken_decode_int_constrained(struct ctoken_decode_ctx *context,
  *  If an error occurs the value 0 will be returned and the error
  *  inside the \c ctoken_decode_ctx will be set.
  */
-enum ctoken_err_t
+void
 ctoken_decode_uint(struct ctoken_decode_ctx *context,
                    int64_t                  label,
                    uint64_t                *claim);
@@ -538,7 +538,7 @@ ctoken_decode_uint(struct ctoken_decode_ctx *context,
  * and the error state inside \c ctoken_decode_ctx will
  * be set.
  */
-enum ctoken_err_t
+void
 ctoken_decode_bstr(struct ctoken_decode_ctx  *context,
                    int64_t                    label,
                    struct q_useful_buf_c     *claim);
@@ -573,7 +573,7 @@ ctoken_decode_bstr(struct ctoken_decode_ctx  *context,
  * and the error state inside \c ctoken_decode_ctx will
  * be set.
  */
-enum ctoken_err_t
+void
 ctoken_decode_tstr(struct ctoken_decode_ctx *context,
                    int64_t                   label,
                    struct q_useful_buf_c    *claim);
@@ -588,7 +588,7 @@ ctoken_decode_tstr(struct ctoken_decode_ctx *context,
  *
  * \return An error from \ref CTOKEN_ERR_t.
  */
-enum ctoken_err_t
+void
 ctoken_decode_bool(struct ctoken_decode_ctx *context,
                    int64_t                   label,
                    bool                     *claim);
@@ -603,7 +603,7 @@ ctoken_decode_bool(struct ctoken_decode_ctx *context,
  *
  * \return An error from \ref CTOKEN_ERR_t.
  */
-enum ctoken_err_t
+void
 ctoken_decode_double(struct ctoken_decode_ctx *context,
                      int64_t                  label,
                      double                  *claim);
@@ -722,7 +722,7 @@ ctoken_decode_exit_map(struct ctoken_decode_ctx *context);
  *  [RFC 8392](https://tools.ietf.org/html/rfc8392#section-3.1.1)
  * and [RFC 7519] (https://tools.ietf.org/html/rfc7519#section-4.1.1).
  */
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_issuer(struct ctoken_decode_ctx *context,
                      struct q_useful_buf_c    *issuer);
 
@@ -750,7 +750,7 @@ ctoken_decode_issuer(struct ctoken_decode_ctx *context,
  * [RFC 8392](https://tools.ietf.org/html/rfc8392#section-3.1.2)
  * and [RFC 7519] (https://tools.ietf.org/html/rfc7519#section-4.1.2).
  */
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_subject(struct ctoken_decode_ctx *context,
                       struct q_useful_buf_c    *subject);
 
@@ -779,7 +779,7 @@ ctoken_decode_subject(struct ctoken_decode_ctx *context,
  * described in [RFC 8392](https://tools.ietf.org/html/rfc8392#section-3.1.3)
  * and [RFC 7519] (https://tools.ietf.org/html/rfc7519#section-4.1.3).
  */
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_audience(struct ctoken_decode_ctx *context,
                        struct q_useful_buf_c    *audience);
 
@@ -914,7 +914,7 @@ ctoken_decode_iat(struct ctoken_decode_ctx *context,
  * and [RFC 7519] (https://tools.ietf.org/html/rfc7519#section-4.1.7).
  * This claim is also used by (EAT)[https://tools.ietf.org/html/draft-ietf-rats-eat-04].
  */
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_cti(struct ctoken_decode_ctx *context,
                   struct q_useful_buf_c    *cti);
 
@@ -940,7 +940,7 @@ ctoken_decode_cti(struct ctoken_decode_ctx *context,
  *
  * This gets the nonce claim out of the token.
  */
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_nonce(struct ctoken_decode_ctx *context,
                     struct q_useful_buf_c    *nonce);
 
@@ -969,7 +969,7 @@ ctoken_decode_nonce(struct ctoken_decode_ctx *context,
  * The UEID is the Universal Entity ID, an opaque binary blob that uniquely
  * identifies the device.
  */
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_ueid(struct ctoken_decode_ctx *context,
                    struct q_useful_buf_c    *ueid);
 
@@ -997,7 +997,7 @@ ctoken_decode_ueid(struct ctoken_decode_ctx *context,
  *
  * The OEMID is an opaque binary blob that identifies the manufacturer.
  */
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_oemid(struct ctoken_decode_ctx *context,
                     struct q_useful_buf_c    *oemid);
 
@@ -1026,7 +1026,7 @@ ctoken_decode_oemid(struct ctoken_decode_ctx *context,
  * This describes the part of the device that created the token. It
  * is a text string or a URI.
  */
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_origination(struct ctoken_decode_ctx *context,
                           struct q_useful_buf_c    *origination);
 
@@ -1085,7 +1085,7 @@ ctoken_decode_security_level(struct ctoken_decode_ctx         *context,
  * The security level gives a rough indication of how security
  * the HW and SW are.  See \ref ctoken_security_level_t.
  */
-static enum ctoken_err_t
+static void
 ctoken_decode_secure_boot(struct ctoken_decode_ctx *context,
                           bool                     *secure_boot_enabled);
 
@@ -1155,7 +1155,7 @@ ctoken_decode_location(struct ctoken_decode_ctx     *context,
  * the error state is entered. It is returned later when
  * ctoken_encode_finish() is called.
  */
-static enum ctoken_err_t
+static void
 ctoken_decode_uptime(struct ctoken_decode_ctx *context,
                      uint64_t                 *uptime);
 
@@ -1187,7 +1187,7 @@ ctoken_decode_intended_use(struct ctoken_decode_ctx   *context,
  *
  * See also ctoken_decode_profile_uri() and ctoken_decode_profile().
  */
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_profile_oid(struct ctoken_decode_ctx *context,
                           struct q_useful_buf_c    *uri);
 
@@ -1202,7 +1202,7 @@ ctoken_decode_profile_oid(struct ctoken_decode_ctx *context,
  *
  * See also ctoken_decode_profile_oid() and ctoken_decode_profile().
  */
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_profile_uri(struct ctoken_decode_ctx *context,
                           struct q_useful_buf_c    *uri);
 
@@ -1223,7 +1223,7 @@ ctoken_decode_profile_uri(struct ctoken_decode_ctx *context,
  * See also ctoken_decode_profile_oid() and
  * ctoken_decode_profile_uri().
  */
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_profile(struct ctoken_decode_ctx *context,
                       bool                     *is_oid_format,
                       struct q_useful_buf_c    *profile);
@@ -1549,27 +1549,27 @@ ctoken_decode_borrow_context(struct ctoken_decode_ctx *me)
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_issuer(struct ctoken_decode_ctx *me,
                      struct q_useful_buf_c    *issuer)
 {
-    return ctoken_decode_tstr(me, CTOKEN_CWT_LABEL_ISSUER, issuer);
+    ctoken_decode_tstr(me, CTOKEN_CWT_LABEL_ISSUER, issuer);
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_subject(struct ctoken_decode_ctx *me,
                       struct q_useful_buf_c    *subject)
 {
-    return ctoken_decode_tstr(me, CTOKEN_CWT_LABEL_SUBJECT, subject);
+    ctoken_decode_tstr(me, CTOKEN_CWT_LABEL_SUBJECT, subject);
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_audience(struct ctoken_decode_ctx *me,
                        struct q_useful_buf_c    *audience)
 {
-    return ctoken_decode_tstr(me, CTOKEN_CWT_LABEL_AUDIENCE, audience);
+    ctoken_decode_tstr(me, CTOKEN_CWT_LABEL_AUDIENCE, audience);
 }
 
 
@@ -1596,71 +1596,64 @@ ctoken_decode_iat(struct ctoken_decode_ctx *me,
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_cti(struct ctoken_decode_ctx *me,
                   struct q_useful_buf_c    *cti)
 {
-    return ctoken_decode_bstr(me, CTOKEN_CWT_LABEL_CTI,  cti);
+    ctoken_decode_bstr(me, CTOKEN_CWT_LABEL_CTI,  cti);
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_nonce(struct ctoken_decode_ctx *me,
                     struct q_useful_buf_c    *nonce)
 {
-    enum ctoken_err_t return_value;
-
-    return_value = ctoken_decode_bstr(me, CTOKEN_EAT_LABEL_NONCE, nonce);
+    ctoken_decode_bstr(me, CTOKEN_EAT_LABEL_NONCE, nonce);
 
 #ifndef CTOKEN_DISABLE_TEMP_LABELS
-    if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
-       return_value = ctoken_decode_bstr(me, CTOKEN_TEMP_EAT_LABEL_NONCE, nonce);
+    if(me->last_error == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
+        me->last_error = CTOKEN_ERR_SUCCESS;
+        ctoken_decode_bstr(me, CTOKEN_TEMP_EAT_LABEL_NONCE, nonce);
     }
 #endif
-
-    return return_value;
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_ueid(struct ctoken_decode_ctx *me,
                    struct q_useful_buf_c    *ueid)
 {
-    enum ctoken_err_t return_value;
-
-    return_value = ctoken_decode_bstr(me, CTOKEN_EAT_LABEL_UEID, ueid);
+    ctoken_decode_bstr(me, CTOKEN_EAT_LABEL_UEID, ueid);
 
 #ifndef CTOKEN_DISABLE_TEMP_LABELS
-    if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
-        return_value = ctoken_decode_bstr(me, CTOKEN_TEMP_EAT_LABEL_UEID, ueid);
+    if(me->last_error == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
+        me->last_error = CTOKEN_ERR_SUCCESS;
+        ctoken_decode_bstr(me, CTOKEN_TEMP_EAT_LABEL_UEID, ueid);
     }
 #endif
-    return return_value;
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_oemid(struct ctoken_decode_ctx *me,
                     struct q_useful_buf_c    *oemid)
 {
-    enum ctoken_err_t return_value;
-
-    return_value = ctoken_decode_bstr(me, CTOKEN_EAT_LABEL_OEMID, oemid);
+    ctoken_decode_bstr(me, CTOKEN_EAT_LABEL_OEMID, oemid);
 
 #ifndef CTOKEN_DISABLE_TEMP_LABELS
-    if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
-        return_value = ctoken_decode_bstr(me, CTOKEN_TEMP_EAT_LABEL_OEMID, oemid);
+    if(me->last_error == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
+        me->last_error = CTOKEN_ERR_SUCCESS;
+        ctoken_decode_bstr(me, CTOKEN_TEMP_EAT_LABEL_OEMID, oemid);
     }
 #endif
-    return return_value;
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_origination(struct ctoken_decode_ctx *me,
                           struct q_useful_buf_c    *origination)
 {
-    return ctoken_decode_tstr(me, CTOKEN_EAT_LABEL_ORIGINATION, origination);
+    ctoken_decode_tstr(me, CTOKEN_EAT_LABEL_ORIGINATION, origination);
 }
 
 
@@ -1686,32 +1679,29 @@ ctoken_decode_security_level(struct ctoken_decode_ctx         *me,
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_uptime(struct ctoken_decode_ctx *me,
                      uint64_t                 *uptime)
 {
-    return ctoken_decode_uint(me, CTOKEN_EAT_LABEL_UPTIME, uptime);
+    ctoken_decode_uint(me, CTOKEN_EAT_LABEL_UPTIME, uptime);
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_secure_boot(struct ctoken_decode_ctx *me,
                           bool                     *secure_boot_enabled)
 {
-    enum ctoken_err_t return_value;
+    ctoken_decode_bool(me, CTOKEN_EAT_LABEL_SECURE_BOOT, secure_boot_enabled);
 
-    return_value = ctoken_decode_bool(me,
-                                      CTOKEN_EAT_LABEL_SECURE_BOOT,
-                                      secure_boot_enabled);
 #ifndef CTOKEN_DISABLE_TEMP_LABELS
-    if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
-        return_value = ctoken_decode_bool(me,
+    if(ctoken_decode_get_error(me) == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
+        // TODO: fix all the other occurances of this construct
+        (void)ctoken_decode_get_and_reset_error(me);
+        ctoken_decode_bool(me,
                                           CTOKEN_TEMP_EAT_LABEL_SECURE_BOOT,
                                           secure_boot_enabled);
     }
 #endif
-
-    return return_value;
 }
 
 
@@ -1748,36 +1738,33 @@ ctoken_decode_intended_use(struct ctoken_decode_ctx    *me,
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_profile_uri(struct ctoken_decode_ctx *me,
                           struct q_useful_buf_c    *profile)
 {
-    return ctoken_decode_tstr(me, CTOKEN_EAT_LABEL_PROFILE, profile);
+    ctoken_decode_tstr(me, CTOKEN_EAT_LABEL_PROFILE, profile);
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_profile_oid(struct ctoken_decode_ctx *me,
                           struct q_useful_buf_c    *profile)
 {
-    return ctoken_decode_bstr(me, CTOKEN_EAT_LABEL_PROFILE, profile);
+    ctoken_decode_bstr(me, CTOKEN_EAT_LABEL_PROFILE, profile);
 }
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_profile(struct ctoken_decode_ctx *me,
                       bool                     *is_oid_format,
                       struct q_useful_buf_c    *profile)
 {
-    enum ctoken_err_t err;
-
     *is_oid_format = false;
-    err = ctoken_decode_profile_uri(me, profile);
-    if(err == CTOKEN_ERR_CBOR_TYPE) {
+    ctoken_decode_profile_uri(me, profile);
+    if(ctoken_decode_get_error(me) == CTOKEN_ERR_CBOR_TYPE) {
+        ctoken_decode_get_and_reset_error(me);
         *is_oid_format = true;
-        err = ctoken_decode_profile_oid(me, profile);
+        ctoken_decode_profile_oid(me, profile);
     }
-
-    return err;
 }
 
 

--- a/inc/ctoken/ctoken_decode.h
+++ b/inc/ctoken/ctoken_decode.h
@@ -1306,7 +1306,7 @@ ctoken_decode_rewind(struct ctoken_decode_ctx   *context);
  * empty the error code returned is CTOKEN_ERR_SUCCESS and the
  * num_submods returned is 0.
  */
-enum ctoken_err_t
+void
 ctoken_decode_get_num_submods(struct ctoken_decode_ctx *context,
                               uint32_t                 *num_submods);
 
@@ -1360,7 +1360,7 @@ ctoken_decode_get_num_submods(struct ctoken_decode_ctx *context,
  * The \c name parameter may be NULL if the submodule name is not of
  * interest.
  */
-enum ctoken_err_t
+void
 ctoken_decode_enter_nth_submod(struct ctoken_decode_ctx *context,
                                uint32_t                  submod_index,
                                struct q_useful_buf_c    *submod_name);
@@ -1402,7 +1402,7 @@ ctoken_decode_enter_nth_submod(struct ctoken_decode_ctx *context,
  * If the submodule with the given name is a nested token, then it is
  * not entered and \ref CTOKEN_ERR_SUBMOD_IS_A_TOKEN is returned.
  */
-enum ctoken_err_t
+void
 ctoken_decode_enter_named_submod(struct ctoken_decode_ctx *context,
                                  const char               *submod_name);
 
@@ -1416,7 +1416,7 @@ ctoken_decode_enter_named_submod(struct ctoken_decode_ctx *context,
  *
  * Pop up one level of submodule nesting.
  */
-enum ctoken_err_t
+void
 ctoken_decode_exit_submod(struct ctoken_decode_ctx *context);
 
 
@@ -1460,7 +1460,7 @@ ctoken_decode_exit_submod(struct ctoken_decode_ctx *context);
  * verification keys and process it like the superior token it came
  * from. JWT format tokens must be processed by a JWT token decoder.
  */
-enum ctoken_err_t
+void
 ctoken_decode_get_nth_nested_token(struct ctoken_decode_ctx *context,
                                    uint32_t                  submod_index,
                                    enum ctoken_type_t       *type,
@@ -1499,7 +1499,7 @@ ctoken_decode_get_nth_nested_token(struct ctoken_decode_ctx *context,
  * See ctoken_decode_get_nth_nested_token() for discussion on the
  * token returned.
  */
-enum ctoken_err_t
+void
 ctoken_decode_get_named_nested_token(struct ctoken_decode_ctx *context,
                                      struct q_useful_buf_c     submod_name,
                                      enum ctoken_type_t       *type,

--- a/inc/ctoken/ctoken_decode.h
+++ b/inc/ctoken/ctoken_decode.h
@@ -399,6 +399,8 @@ ctoken_decode_get_payload(struct ctoken_decode_ctx *context,
  * data items in the map works well. The CBOR nesting
  * level must be left the same as it was before the
  * claim(s) were decoded.
+
+ // TODO: what about error state?
  */
 static QCBORDecodeContext *
 ctoken_decode_borrow_context(struct ctoken_decode_ctx *context);
@@ -629,7 +631,7 @@ ctoken_decode_double(struct ctoken_decode_ctx *context,
  * QCBOR_ERR_NO_MORE_ITEMS.  The array may contain other arrays and
  * maps.
  */
-enum ctoken_err_t
+void
 ctoken_decode_enter_array(struct ctoken_decode_ctx *context,
                           int64_t                   label,
                           QCBORDecodeContext      **decoder);
@@ -650,7 +652,7 @@ ctoken_decode_enter_array(struct ctoken_decode_ctx *context,
  * the claim must be exitied if they were entered before this is
  * called.
  */
-enum ctoken_err_t
+void
 ctoken_decode_exit_array(struct ctoken_decode_ctx *context);
 
 
@@ -674,7 +676,7 @@ ctoken_decode_exit_array(struct ctoken_decode_ctx *context);
  * QCBORDecode_EnterArrayFromMapN() can then be called.  The map may
  * contain other arrays and maps.
  */
-enum ctoken_err_t
+void
 ctoken_decode_enter_map(struct ctoken_decode_ctx *context,
                         int64_t                   label,
                         QCBORDecodeContext      **decoder);
@@ -695,7 +697,7 @@ ctoken_decode_enter_map(struct ctoken_decode_ctx *context,
  * the claim must be exitied if they were entered before this is
  * called.
  */
-enum ctoken_err_t
+void
 ctoken_decode_exit_map(struct ctoken_decode_ctx *context);
 
 
@@ -1136,7 +1138,7 @@ ctoken_decode_debug_state(struct ctoken_decode_ctx  *context,
  * Only some of the values in the location claim may be present. See
  * \ref ctoken_location_t for how the data is returned.
  */
-enum ctoken_err_t
+void
 ctoken_decode_location(struct ctoken_decode_ctx     *context,
                        struct ctoken_location_t *location);
 

--- a/inc/ctoken/ctoken_decode_psa.h
+++ b/inc/ctoken/ctoken_decode_psa.h
@@ -64,9 +64,13 @@ ctoken_decode_psa_simple_claims(struct ctoken_decode_ctx          *context,
  * \param[in]  context         The token decoder context.
  * \param[out] boot_seed  Returned pointer and length of boot_seed.
  *
- * \return An error from \ref CTOKEN_ERR_t.
- *
  * The boot seed is a byte string.
+ *
+ * The error result is saved in the @ref ctoken_decode_ctx and can be
+ * obtained by calling ctoken_decode_get_error(). The error must
+ * be checked before the claim's value is used, but that check can be
+ * after decoding other claims.  See
+ * [Token Decode Error Overview](#Token-Decode-Errors-Overview).
  */
 static void
 ctoken_decode_psa_boot_seed(struct ctoken_decode_ctx *context,
@@ -80,12 +84,16 @@ ctoken_decode_psa_boot_seed(struct ctoken_decode_ctx *context,
  * \param[out] hw_version  Returned pointer and length of
  *                         \c hw_version.
  *
- * \return An error from \ref CTOKEN_ERR_t.
- *
  * This is also known as the HW ID.
  *
  * The HW Version is a UTF-8 text string. It is returned as a pointer
  * and length. It is NOT \c NULL terminated.
+ *
+ * The error result is saved in the @ref ctoken_decode_ctx and can be
+ * obtained by calling ctoken_decode_get_error(). The error must
+ * be checked before the claim's value is used, but that check can be
+ * after decoding other claims.  See
+ * [Token Decode Error Overview](#Token-Decode-Errors-Overview).
  */
 static void
 ctoken_decode_psa_hw_version(struct ctoken_decode_ctx *context,
@@ -99,9 +107,13 @@ ctoken_decode_psa_hw_version(struct ctoken_decode_ctx *context,
  * \param[out] implementation_id  Returned pointer and length of
  *                                implementation_id.
  *
- * \return An error from \ref CTOKEN_ERR_t.
- *
  * The implementation ID is a byte string.
+ *
+ * The error result is saved in the @ref ctoken_decode_ctx and can be
+ * obtained by calling ctoken_decode_get_error(). The error must
+ * be checked before the claim's value is used, but that check can be
+ * after decoding other claims.  See
+ * [Token Decode Error Overview](#Token-Decode-Errors-Overview).
  */
 static void
 ctoken_decode_psa_implementation_id(struct ctoken_decode_ctx *context,
@@ -114,12 +126,16 @@ ctoken_decode_psa_implementation_id(struct ctoken_decode_ctx *context,
  * \param[in]  context           The token decoder context.
  * \param[out] origination  Returned pointer and length of origination.
  *
- * \return An error from \ref CTOKEN_ERR_t.
- *
  * This is also known as the Verification Service Indicator.
  *
  * The \c origination is a UTF-8 text string. It is returned as a
  * pointer and length. It is NOT \c NULL terminated.
+ *
+ * The error result is saved in the @ref ctoken_decode_ctx and can be
+ * obtained by calling ctoken_decode_get_error(). The error must
+ * be checked before the claim's value is used, but that check can be
+ * after decoding other claims.  See
+ * [Token Decode Error Overview](#Token-Decode-Errors-Overview).
  */
 static void
 ctoken_decode_psa_origination(struct ctoken_decode_ctx *context,
@@ -133,10 +149,14 @@ ctoken_decode_psa_origination(struct ctoken_decode_ctx *context,
  * \param[out] profile_definition  Returned pointer and length of
  *                                 profile_definition.
  *
- * \return An error from \ref CTOKEN_ERR_t.
- *
  * The profile definition is a UTF-8 text string. It is returned as a
  * pointer and length. It is NOT \c NULL terminated.
+ *
+ * The error result is saved in the @ref ctoken_decode_ctx and can be
+ * obtained by calling ctoken_decode_get_error(). The error must
+ * be checked before the claim's value is used, but that check can be
+ * after decoding other claims.  See
+ * [Token Decode Error Overview](#Token-Decode-Errors-Overview).
  */
 static void
 ctoken_decode_psa_profile_definition(struct ctoken_decode_ctx *context,
@@ -149,13 +169,17 @@ ctoken_decode_psa_profile_definition(struct ctoken_decode_ctx *context,
  * \param[in]  context         The token decoder context.
  * \param[out] client_id  Returned pointer and length of client_id.
  *
- * \return An error from \ref CTOKEN_ERR_t.
- *
  * \retval CTOKEN_ERR_INTEGER_VALUE
  *         If integer is larger or smaller than will fit
  *         in an \c int32_t.
  *
  * Also called the caller ID.
+ *
+ * The error result is saved in the @ref ctoken_decode_ctx and can be
+ * obtained by calling ctoken_decode_get_error(). The error must
+ * be checked before the claim's value is used, but that check can be
+ * after decoding other claims.  See
+ * [Token Decode Error Overview](#Token-Decode-Errors-Overview).
  */
 static void
 ctoken_decode_psa_client_id(struct ctoken_decode_ctx *context,
@@ -168,11 +192,15 @@ ctoken_decode_psa_client_id(struct ctoken_decode_ctx *context,
  * \param[in]  context         The token decoder context.
  * \param[out] lifecycle  Returned pointer and length of lifecycle.
  *
- * \return An error from \ref CTOKEN_ERR_t.
- *
  * \retval CTOKEN_ERR_INTEGER_VALUE
  *         If integer is larger
  *         or smaller than will fit in a \c uint32_t.
+ *
+ * The error result is saved in the @ref ctoken_decode_ctx and can be
+ * obtained by calling ctoken_decode_get_error(). The error must
+ * be checked before the claim's value is used, but that check can be
+ * after decoding other claims.  See
+ * [Token Decode Error Overview](#Token-Decode-Errors-Overview).
  */
 static void
 ctoken_decode_psa_security_lifecycle(struct ctoken_decode_ctx *context,

--- a/inc/ctoken/ctoken_decode_psa.h
+++ b/inc/ctoken/ctoken_decode_psa.h
@@ -157,7 +157,7 @@ ctoken_decode_psa_profile_definition(struct ctoken_decode_ctx *context,
  *
  * Also called the caller ID.
  */
-static enum ctoken_err_t
+static void
 ctoken_decode_psa_client_id(struct ctoken_decode_ctx *context,
                             int32_t                  *client_id);
 
@@ -293,25 +293,21 @@ ctoken_decode_psa_implementation_id(struct ctoken_decode_ctx *me,
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_psa_client_id(struct ctoken_decode_ctx *me,
                             int32_t                  *caller_id)
 {
-    enum ctoken_err_t return_value;
     int64_t caller_id_64;
 
-    return_value = ctoken_decode_int(me, CTOKEN_PSA_LABEL_CLIENT_ID, &caller_id_64);
-    if(return_value != CTOKEN_ERR_SUCCESS) {
-        goto Done;
+    ctoken_decode_int(me, CTOKEN_PSA_LABEL_CLIENT_ID, &caller_id_64);
+    if(me->last_error != CTOKEN_ERR_SUCCESS) {
+        return;
     }
     if(caller_id_64 > INT32_MAX || caller_id_64 < INT32_MIN) {
-        return_value = CTOKEN_ERR_INTEGER_VALUE;
-        goto Done;
+        me->last_error = CTOKEN_ERR_INTEGER_VALUE;
+        return;
     }
     *caller_id = (int32_t)caller_id_64;
-
-Done:
-    return return_value;
 }
 
 

--- a/inc/ctoken/ctoken_decode_psa.h
+++ b/inc/ctoken/ctoken_decode_psa.h
@@ -68,7 +68,7 @@ ctoken_decode_psa_simple_claims(struct ctoken_decode_ctx          *context,
  *
  * The boot seed is a byte string.
  */
-static enum ctoken_err_t
+static void
 ctoken_decode_psa_boot_seed(struct ctoken_decode_ctx *context,
                             struct q_useful_buf_c    *boot_seed);
 
@@ -87,7 +87,7 @@ ctoken_decode_psa_boot_seed(struct ctoken_decode_ctx *context,
  * The HW Version is a UTF-8 text string. It is returned as a pointer
  * and length. It is NOT \c NULL terminated.
  */
-static enum ctoken_err_t
+static void
 ctoken_decode_psa_hw_version(struct ctoken_decode_ctx *context,
                              struct q_useful_buf_c    *hw_version);
 
@@ -103,7 +103,7 @@ ctoken_decode_psa_hw_version(struct ctoken_decode_ctx *context,
  *
  * The implementation ID is a byte string.
  */
-static enum ctoken_err_t
+static void
 ctoken_decode_psa_implementation_id(struct ctoken_decode_ctx *context,
                                     struct q_useful_buf_c    *implementation_id);
 
@@ -121,7 +121,7 @@ ctoken_decode_psa_implementation_id(struct ctoken_decode_ctx *context,
  * The \c origination is a UTF-8 text string. It is returned as a
  * pointer and length. It is NOT \c NULL terminated.
  */
-static enum ctoken_err_t
+static void
 ctoken_decode_psa_origination(struct ctoken_decode_ctx *context,
                               struct q_useful_buf_c    *origination);
 
@@ -138,7 +138,7 @@ ctoken_decode_psa_origination(struct ctoken_decode_ctx *context,
  * The profile definition is a UTF-8 text string. It is returned as a
  * pointer and length. It is NOT \c NULL terminated.
  */
-static enum ctoken_err_t
+static void
 ctoken_decode_psa_profile_definition(struct ctoken_decode_ctx *context,
                                      struct q_useful_buf_c    *profile_definition);
 
@@ -174,7 +174,7 @@ ctoken_decode_psa_client_id(struct ctoken_decode_ctx *context,
  *         If integer is larger
  *         or smaller than will fit in a \c uint32_t.
  */
-static enum ctoken_err_t
+static void
 ctoken_decode_psa_security_lifecycle(struct ctoken_decode_ctx *context,
                                      uint32_t                 *lifecycle);
 
@@ -269,27 +269,27 @@ ctoken_decode_psa_sw_component(struct ctoken_decode_ctx         *context,
  * --------------------------------------------------------------------------*/
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_psa_boot_seed(struct ctoken_decode_ctx *me,
                             struct q_useful_buf_c    *boot_seed)
 {
-    return ctoken_decode_bstr(me, CTOKEN_PSA_LABEL_BOOT_SEED, boot_seed);
+    ctoken_decode_bstr(me, CTOKEN_PSA_LABEL_BOOT_SEED, boot_seed);
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_psa_hw_version(struct ctoken_decode_ctx *me,
                              struct q_useful_buf_c    *hw_version)
 {
-    return ctoken_decode_tstr(me, CTOKEN_PSA_LABEL_HW_VERSION, hw_version);
+    ctoken_decode_tstr(me, CTOKEN_PSA_LABEL_HW_VERSION, hw_version);
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_psa_implementation_id(struct ctoken_decode_ctx *me,
                                     struct q_useful_buf_c    *implementation_id)
 {
-    return ctoken_decode_bstr(me, CTOKEN_PSA_LABEL_IMPLEMENTATION_ID, implementation_id);
+    ctoken_decode_bstr(me, CTOKEN_PSA_LABEL_IMPLEMENTATION_ID, implementation_id);
 }
 
 
@@ -311,41 +311,40 @@ ctoken_decode_psa_client_id(struct ctoken_decode_ctx *me,
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_psa_security_lifecycle(struct ctoken_decode_ctx *me,
                                      uint32_t                 *security_lifecycle)
 {
-    enum ctoken_err_t return_value;
     uint64_t security_lifecycle_64;
 
-    return_value = ctoken_decode_uint(me,
+    ctoken_decode_uint(me,
                                       CTOKEN_PSA_LABEL_SECURITY_LIFECYCLE,
                                       &security_lifecycle_64);
+    if(me->last_error != CTOKEN_ERR_SUCCESS) {
+        return;
+    }
     if(security_lifecycle_64 > UINT32_MAX) {
-        return_value = CTOKEN_ERR_INTEGER_VALUE;
-        goto Done;
+        me->last_error = CTOKEN_ERR_INTEGER_VALUE;
+        return;
     }
 
     *security_lifecycle = (uint32_t)security_lifecycle_64;
-
-Done:
-    return return_value;
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_psa_profile_definition(struct ctoken_decode_ctx *me,
                                      struct q_useful_buf_c    *profile_definition)
 {
-    return ctoken_decode_tstr(me, CTOKEN_PSA_LABEL_PROFILE_DEFINITION, profile_definition);
+    ctoken_decode_tstr(me, CTOKEN_PSA_LABEL_PROFILE_DEFINITION, profile_definition);
 }
 
 
-static inline enum ctoken_err_t
+static inline void
 ctoken_decode_psa_origination(struct ctoken_decode_ctx *me,
                               struct q_useful_buf_c    *origination)
 {
-    return ctoken_decode_origination(me, origination);
+    ctoken_decode_origination(me, origination);
 }
 
 #ifdef __cplusplus

--- a/src/ctoken_decode.c
+++ b/src/ctoken_decode.c
@@ -981,6 +981,8 @@ ctoken_decode_nested_token(struct ctoken_decode_ctx  *me,
 {
     enum ctoken_err_t return_value;
 
+    *token = NULL_Q_USEFUL_BUF_C;
+
     return_value = get_and_reset_error(&(me->qcbor_decode_context));
 
     if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT ||

--- a/src/ctoken_decode.c
+++ b/src/ctoken_decode.c
@@ -145,7 +145,7 @@ get_nth_tag(struct ctoken_decode_ctx *me, int protection_type, QCBORItem *item, 
 /*
  * Public function. See ctoken_decode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_validate_token(struct ctoken_decode_ctx *me,
                              struct q_useful_buf_c     token)
 {
@@ -245,7 +245,6 @@ Done:
     if(return_value != CTOKEN_ERR_SUCCESS) {
         me->actual_protection_type = CTOKEN_PROTECTION_UNKNOWN;
     }
-    return return_value;
 }
 
 
@@ -554,11 +553,15 @@ static bool is_submod_section(const QCBORItem *claim)
 /*
  * Public function. See ctoken_eat_encode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_next_claim(struct ctoken_decode_ctx   *me,
                          QCBORItem                  *claim)
 {
     enum ctoken_err_t return_value;
+
+    if(me->last_error) {
+        return;
+    }
 
     /* Loop is only to skip the submods section and executes only
      * once in most cases. It executes twice if there is a submods section.
@@ -578,7 +581,7 @@ ctoken_decode_next_claim(struct ctoken_decode_ctx   *me,
     claim->uNextNestLevel = 0;
 
 Done:
-    return return_value;
+    me->last_error = return_value;
 }
 
 

--- a/src/ctoken_decode.c
+++ b/src/ctoken_decode.c
@@ -714,12 +714,16 @@ Done:
 /*
  * Public function. See ctoken_decode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_get_num_submods(struct ctoken_decode_ctx *me,
                               uint32_t                 *num_submods)
 {
     enum ctoken_err_t return_value;
     enum ctoken_err_t return_value2;
+
+    if(me->last_error) {
+        return;
+    }
 
     return_value = enter_submod_section(me);
     if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
@@ -739,14 +743,14 @@ ctoken_decode_get_num_submods(struct ctoken_decode_ctx *me,
     }
 
 Done:
-    return return_value;
+    me->last_error = return_value;
 }
 
 
 /*
  * Public function. See ctoken_decode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_enter_nth_submod(struct ctoken_decode_ctx *me,
                                uint32_t                  submod_index,
                                struct q_useful_buf_c    *name)
@@ -756,6 +760,9 @@ ctoken_decode_enter_nth_submod(struct ctoken_decode_ctx *me,
     uint32_t          num_submods;
     QCBORError        cbor_error;
 
+    if(me->last_error) {
+        return;
+    }
 
     return_value = enter_submod_section(me);
     if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
@@ -846,19 +853,23 @@ Done:
     }
 
 Done2:
-    return return_value;
+    me->last_error = return_value;
 }
 
 
 /*
  * Public function. See ctoken_decode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_enter_named_submod(struct ctoken_decode_ctx *me,
                                  const char               *name)
 {
     enum ctoken_err_t     return_value;
     QCBORItem             item;
+
+    if(me->last_error) {
+        return;
+    }
 
     return_value = enter_submod_section(me);
     if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
@@ -913,17 +924,21 @@ Done:
         leave_submod_section(me);
     }
 Done2:
-    return return_value;
+    me->last_error = return_value;
 }
 
 
 /*
  * Public function. See ctoken_decode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_exit_submod(struct ctoken_decode_ctx *me)
 {
     enum ctoken_err_t return_value;
+
+    if(me->last_error) {
+        return;
+    }
 
     if(me->submod_nest_level == 0) {
         return_value = CTOKEN_ERR_NO_SUBMOD_OPEN;
@@ -944,7 +959,7 @@ ctoken_decode_exit_submod(struct ctoken_decode_ctx *me)
     }
 
 Done:
-    return return_value;
+    me->last_error = return_value;
 }
 
 
@@ -996,7 +1011,7 @@ Done:
 /*
  * Public function. See ctoken_decode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_get_named_nested_token(struct ctoken_decode_ctx *me,
                                      struct q_useful_buf_c     submod_name,
                                      enum ctoken_type_t       *type,
@@ -1006,6 +1021,9 @@ ctoken_decode_get_named_nested_token(struct ctoken_decode_ctx *me,
     enum ctoken_err_t return_value2;
     QCBORItem         search[2];
 
+    if(me->last_error) {
+        return;
+    }
 
     return_value = enter_submod_section(me);
     if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
@@ -1033,14 +1051,14 @@ ctoken_decode_get_named_nested_token(struct ctoken_decode_ctx *me,
     }
 
 Done:
-    return return_value;
+    me->last_error = return_value;
 }
 
 
 /*
  * Public function. See ctoken_decode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_get_nth_nested_token(struct ctoken_decode_ctx *me,
                                    uint32_t                  submod_index,
                                    enum ctoken_type_t       *type,
@@ -1051,6 +1069,10 @@ ctoken_decode_get_nth_nested_token(struct ctoken_decode_ctx *me,
     enum ctoken_err_t return_value;
     enum ctoken_err_t return_value2;
     uint32_t          returned_index;
+
+    if(me->last_error) {
+        return;
+    }
 
     return_value = enter_submod_section(me);
     if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
@@ -1090,6 +1112,6 @@ Done:
     }
 
 Done2:
-    return return_value;
+    me->last_error = return_value;
 }
 

--- a/src/ctoken_decode.c
+++ b/src/ctoken_decode.c
@@ -415,13 +415,16 @@ ctoken_decode_enter_map(struct ctoken_decode_ctx *me,
                         QCBORDecodeContext     **decoder)
 {
     if(me->last_error != CTOKEN_ERR_SUCCESS) {
-    return;
+        return;
     }
 
     QCBORDecode_EnterMapFromMapN(&(me->qcbor_decode_context), label);
     me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
-    *decoder = &(me->qcbor_decode_context);
-}
+    if(me->last_error == CTOKEN_ERR_SUCCESS) {
+        *decoder = &(me->qcbor_decode_context);
+    } else {
+        *decoder = NULL;
+    }}
 
 
 /*
@@ -449,7 +452,11 @@ ctoken_decode_enter_array(struct ctoken_decode_ctx *me,
 
     QCBORDecode_EnterArrayFromMapN(&(me->qcbor_decode_context), label);
     me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
-    *decoder = &(me->qcbor_decode_context);
+    if(me->last_error == CTOKEN_ERR_SUCCESS) {
+        *decoder = &(me->qcbor_decode_context);
+    } else {
+        *decoder = NULL;
+    }
 }
 
 

--- a/src/ctoken_decode.c
+++ b/src/ctoken_decode.c
@@ -252,25 +252,19 @@ Done:
 /*
  * Public function. See ctoken_decode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_bstr(struct ctoken_decode_ctx *me,
                    int64_t                  label,
                    struct q_useful_buf_c   *claim)
 {
-    enum ctoken_err_t return_value;
-
     if(me->last_error != CTOKEN_ERR_SUCCESS) {
-        return_value = me->last_error;
         *claim = NULL_Q_USEFUL_BUF_C;
-        goto Done;
+        return;
     }
 
     QCBORDecode_GetByteStringInMapN(&(me->qcbor_decode_context), label, claim);
 
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
-
-Done:
-    return return_value;
+    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
 }
 
 
@@ -305,25 +299,19 @@ Done:
 /*
  * Public function. See ctoken_decode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_tstr(struct ctoken_decode_ctx *me,
                    int64_t                   label,
                    struct q_useful_buf_c    *claim)
 {
-    enum ctoken_err_t return_value;
-
     if(me->last_error != CTOKEN_ERR_SUCCESS) {
-        return_value = me->last_error;
         *claim = NULL_Q_USEFUL_BUF_C;
-        goto Done;
+        return;
     }
 
     QCBORDecode_GetTextStringInMapN(&(me->qcbor_decode_context), label, claim);
 
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
-
-Done:
-    return return_value;
+    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
 }
 
 
@@ -369,73 +357,53 @@ ctoken_decode_int_constrained(struct ctoken_decode_ctx *me,
 /*
  * Public function. See ctoken_decode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_uint(struct ctoken_decode_ctx *me,
                    int64_t                   label,
                    uint64_t                 *integer)
 {
-    enum ctoken_err_t return_value;
-
     if(me->last_error != CTOKEN_ERR_SUCCESS) {
-        return_value = me->last_error;
-        *integer = 0;
-        goto Done;
+        return;
     }
 
     QCBORDecode_GetUInt64InMapN(&(me->qcbor_decode_context), label, integer);
 
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
-
-Done:
-    return return_value;
+    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
 }
 
 
 /*
  * Public function. See ctoken_decode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_double(struct ctoken_decode_ctx *me,
                      int64_t                  label,
                      double                  *claim)
 {
-    enum ctoken_err_t return_value;
-
     if(me->last_error != CTOKEN_ERR_SUCCESS) {
-        return_value = me->last_error;
-        *claim = 0;
-        goto Done;
+        return;
     }
 
     QCBORDecode_GetDoubleInMapN(&(me->qcbor_decode_context), label, claim);
 
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
-
-Done:
-    return return_value;
+    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
 }
 
 /*
  * Public function. See ctoken_decode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_bool(struct ctoken_decode_ctx *me,
                    int64_t                   label,
                    bool                     *b)
 {
-    enum ctoken_err_t return_value;
-
     if(me->last_error != CTOKEN_ERR_SUCCESS) {
-        return_value = me->last_error;
-        goto Done;
+        return;
     }
 
     QCBORDecode_GetBoolInMapN(&(me->qcbor_decode_context), label, b);
 
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
-
-Done:
-    return return_value;
+    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
 }
 
 

--- a/src/ctoken_decode.c
+++ b/src/ctoken_decode.c
@@ -330,51 +330,39 @@ Done:
 /*
  * Public function. See ctoken_decode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_int(struct ctoken_decode_ctx *me,
                   int64_t                   label,
                   int64_t                  *integer)
 {
-    enum ctoken_err_t return_value;
-
     if(me->last_error != CTOKEN_ERR_SUCCESS) {
-        return_value = me->last_error;
-        *integer = 0;
-        goto Done;
+        return;
     }
 
     QCBORDecode_GetInt64InMapN(&(me->qcbor_decode_context), label, integer);
 
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
-
-Done:
-    return return_value;
+    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
 }
 
 
 /*
  * Public function. See ctoken_eat_encode.h
  */
-enum ctoken_err_t
+void
 ctoken_decode_int_constrained(struct ctoken_decode_ctx *me,
                               int64_t                   label,
                               int64_t                   min,
                               int64_t                   max,
                               int64_t                  *claim)
 {
-    enum ctoken_err_t return_value;
-
-    return_value = ctoken_decode_int(me, label, claim);
-    if(return_value != CTOKEN_ERR_SUCCESS) {
-        goto Done;
+    ctoken_decode_int(me, label, claim);
+    if(me->last_error != CTOKEN_ERR_SUCCESS) {
+        return;
     }
 
     if(*claim < min || *claim > max) {
-        return_value = CTOKEN_ERR_CLAIM_RANGE;
+        me->last_error = CTOKEN_ERR_CLAIM_RANGE;
     }
-
-Done:
-    return return_value;
 }
 
 

--- a/src/ctoken_decode.c
+++ b/src/ctoken_decode.c
@@ -67,7 +67,7 @@ void ctoken_decode_init(struct ctoken_decode_ctx *me,
  *
  * \return The ctoken error.
  */
-enum ctoken_err_t get_and_reset_error(QCBORDecodeContext *decode_context)
+enum ctoken_err_t ctoken_get_and_reset_cbor_error(QCBORDecodeContext *decode_context)
 {
     QCBORError cbor_error;
 
@@ -236,7 +236,7 @@ ctoken_decode_validate_token(struct ctoken_decode_ctx *me,
     /* Now processing for either COSE-secured or UCCS. Enter the map
        that holds all the claims */
     QCBORDecode_EnterMap(&(me->qcbor_decode_context), NULL);
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
+    return_value = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 
     me->submod_nest_level = 0;
 
@@ -263,7 +263,7 @@ ctoken_decode_bstr(struct ctoken_decode_ctx *me,
 
     QCBORDecode_GetByteStringInMapN(&(me->qcbor_decode_context), label, claim);
 
-    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
+    me->last_error = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 }
 
 
@@ -310,7 +310,7 @@ ctoken_decode_tstr(struct ctoken_decode_ctx *me,
 
     QCBORDecode_GetTextStringInMapN(&(me->qcbor_decode_context), label, claim);
 
-    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
+    me->last_error = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 }
 
 
@@ -328,7 +328,7 @@ ctoken_decode_int(struct ctoken_decode_ctx *me,
 
     QCBORDecode_GetInt64InMapN(&(me->qcbor_decode_context), label, integer);
 
-    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
+    me->last_error = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 }
 
 
@@ -367,7 +367,7 @@ ctoken_decode_uint(struct ctoken_decode_ctx *me,
 
     QCBORDecode_GetUInt64InMapN(&(me->qcbor_decode_context), label, integer);
 
-    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
+    me->last_error = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 }
 
 
@@ -385,7 +385,7 @@ ctoken_decode_double(struct ctoken_decode_ctx *me,
 
     QCBORDecode_GetDoubleInMapN(&(me->qcbor_decode_context), label, claim);
 
-    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
+    me->last_error = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 }
 
 /*
@@ -402,7 +402,7 @@ ctoken_decode_bool(struct ctoken_decode_ctx *me,
 
     QCBORDecode_GetBoolInMapN(&(me->qcbor_decode_context), label, b);
 
-    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
+    me->last_error = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 }
 
 
@@ -419,7 +419,7 @@ ctoken_decode_enter_map(struct ctoken_decode_ctx *me,
     }
 
     QCBORDecode_EnterMapFromMapN(&(me->qcbor_decode_context), label);
-    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
+    me->last_error = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
     if(me->last_error == CTOKEN_ERR_SUCCESS) {
         *decoder = &(me->qcbor_decode_context);
     } else {
@@ -434,7 +434,7 @@ void
 ctoken_decode_exit_map(struct ctoken_decode_ctx *me)
 {
     QCBORDecode_ExitMap(&(me->qcbor_decode_context));
-    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
+    me->last_error = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 }
 
 
@@ -451,7 +451,7 @@ ctoken_decode_enter_array(struct ctoken_decode_ctx *me,
     }
 
     QCBORDecode_EnterArrayFromMapN(&(me->qcbor_decode_context), label);
-    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
+    me->last_error = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
     if(me->last_error == CTOKEN_ERR_SUCCESS) {
         *decoder = &(me->qcbor_decode_context);
     } else {
@@ -467,7 +467,7 @@ void
 ctoken_decode_exit_array(struct ctoken_decode_ctx *me)
 {
     QCBORDecode_ExitArray(&(me->qcbor_decode_context));
-    me->last_error = get_and_reset_error(&(me->qcbor_decode_context));
+    me->last_error = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 }
 
 
@@ -501,7 +501,7 @@ ctoken_decode_location(struct ctoken_decode_ctx   *me,
 
     for(label = CTOKEN_EAT_LABEL_LATITUDE; label <= NUM_FLOAT_LOCATION_ITEMS; label++) {
         QCBORDecode_GetDoubleInMapN(decoder, label, &d);
-        me->last_error = get_and_reset_error(decoder);
+        me->last_error = ctoken_get_and_reset_cbor_error(decoder);
         if(me->last_error == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
             continue;
         }
@@ -521,7 +521,7 @@ ctoken_decode_location(struct ctoken_decode_ctx   *me,
     }
 
     QCBORDecode_GetUInt64InMapN(decoder, CTOKEN_EAT_LABEL_TIME_STAMP, &(location->time_stamp));
-    me->last_error = get_and_reset_error(decoder);
+    me->last_error = ctoken_get_and_reset_cbor_error(decoder);
     if(me->last_error == CTOKEN_ERR_SUCCESS) {
         ctoken_location_mark_item_present(location, CTOKEN_EAT_LABEL_TIME_STAMP);
     } else if(me->last_error != CTOKEN_ERR_CLAIM_NOT_PRESENT) {
@@ -529,7 +529,7 @@ ctoken_decode_location(struct ctoken_decode_ctx   *me,
     }
 
     QCBORDecode_GetUInt64InMapN(decoder, CTOKEN_EAT_LABEL_AGE, &(location->age));
-    me->last_error = get_and_reset_error(decoder);
+    me->last_error = ctoken_get_and_reset_cbor_error(decoder);
     if(me->last_error == CTOKEN_ERR_SUCCESS) {
         ctoken_location_mark_item_present(location, CTOKEN_EAT_LABEL_AGE);
     } else if(me->last_error != CTOKEN_ERR_CLAIM_NOT_PRESENT) {
@@ -577,7 +577,7 @@ ctoken_decode_next_claim(struct ctoken_decode_ctx   *me,
     do {
         QCBORDecode_VGetNextConsume(&(me->qcbor_decode_context), claim);
 
-        return_value = get_and_reset_error(&(me->qcbor_decode_context));
+        return_value = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
         if(return_value != CTOKEN_ERR_SUCCESS) {
             goto Done;
         }
@@ -635,13 +635,13 @@ enter_submod_section(struct ctoken_decode_ctx *me)
     QCBORDecode_EnterMapFromMapN(&(me->qcbor_decode_context),
                                  CTOKEN_EAT_LABEL_SUBMODS);
 
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
+    return_value = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 
 #ifndef CTOKEN_DISABLE_TEMP_LABELS
     if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
         QCBORDecode_EnterMapFromMapN(&(me->qcbor_decode_context),
                                      CTOKEN_TEMP_EAT_LABEL_SUBMODS);
-        return_value = get_and_reset_error(&(me->qcbor_decode_context));
+        return_value = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
     }
 #endif
 
@@ -655,7 +655,7 @@ leave_submod_section(struct ctoken_decode_ctx *me)
 {
     QCBORDecode_ExitMap(&(me->qcbor_decode_context));
 
-    return get_and_reset_error(&(me->qcbor_decode_context));
+    return ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 }
 
 
@@ -702,7 +702,7 @@ ctoken_decode_to_nth_submod(struct ctoken_decode_ctx *me,
 
     while(submod_index > 0) {
         QCBORDecode_VGetNextConsume(decode_context, &map_item);
-        return_value = get_and_reset_error(decode_context);
+        return_value = ctoken_get_and_reset_cbor_error(decode_context);
         if(return_value != CTOKEN_ERR_SUCCESS) {
             break;
         }
@@ -840,7 +840,7 @@ ctoken_decode_enter_nth_submod(struct ctoken_decode_ctx *me,
      * that the rest will succeed. */
 
     QCBORDecode_EnterMap(&(me->qcbor_decode_context), &item);
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
+    return_value = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
     if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
         /* This should never happen because the QCBORDecode_PeekNext()
          * succeeded.
@@ -895,7 +895,7 @@ ctoken_decode_enter_named_submod(struct ctoken_decode_ctx *me,
 
     /* Try to enter has a map */
     QCBORDecode_EnterMapFromMapSZ(&(me->qcbor_decode_context), name);
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
+    return_value = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
     if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
         return_value = CTOKEN_ERR_SUBMOD_NOT_FOUND;
         goto Done;
@@ -908,7 +908,7 @@ ctoken_decode_enter_named_submod(struct ctoken_decode_ctx *me,
     if(return_value == CTOKEN_ERR_CBOR_TYPE) {
         /* It wasn't a map. If it is a bstr or tstr, then it's a nested token */
         QCBORDecode_GetItemInMapSZ(&(me->qcbor_decode_context), name, QCBOR_TYPE_ANY, &item);
-        return_value = get_and_reset_error(&(me->qcbor_decode_context));
+        return_value = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
         if(return_value != CTOKEN_ERR_SUCCESS) {
             /* An error with malformed or invalid input. Error probably
              * always occurs in attempt to enter as a map above rather
@@ -956,7 +956,7 @@ ctoken_decode_exit_submod(struct ctoken_decode_ctx *me)
     }
 
     QCBORDecode_ExitMap(&(me->qcbor_decode_context));
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
+    return_value = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
     if(return_value != CTOKEN_ERR_SUCCESS) {
         goto Done;
     }
@@ -983,7 +983,7 @@ ctoken_decode_nested_token(struct ctoken_decode_ctx  *me,
 
     *token = NULL_Q_USEFUL_BUF_C;
 
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
+    return_value = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 
     if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT ||
        return_value == CTOKEN_ERR_NO_MORE_CLAIMS) {

--- a/src/ctoken_decode_psa.c
+++ b/src/ctoken_decode_psa.c
@@ -189,7 +189,7 @@ get_no_sw_component_indicator(struct ctoken_decode_ctx *me, bool *no_sw_componen
                               QCBOR_TYPE_INT64,
                              &item);
 
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
+    return_value = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 
     if(return_value == CTOKEN_ERR_SUCCESS) {
         if(item.val.int64 == NO_SW_COMPONENT_FIXED_VALUE) {
@@ -266,7 +266,7 @@ ctoken_decode_psa_num_sw_components(struct ctoken_decode_ctx *me,
     }
 
     QCBORDecode_EnterArrayFromMapN(&(me->qcbor_decode_context), CTOKEN_PSA_LABEL_SW_COMPONENTS);
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
+    return_value = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 
     if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
         /* There is no SW components claim. */
@@ -291,7 +291,7 @@ ctoken_decode_psa_num_sw_components(struct ctoken_decode_ctx *me,
     }
 
     CountItems(&(me->qcbor_decode_context), num_sw_components);
-    return_value = get_and_reset_error(&(me->qcbor_decode_context));
+    return_value = ctoken_get_and_reset_cbor_error(&(me->qcbor_decode_context));
 
     if(*num_sw_components == 0) {
          /* Empty SW component not allowed */
@@ -324,7 +324,7 @@ decode_psa_sw_component(QCBORDecodeContext               *decode_context,
     QCBORItem          list[CTOKEN_PSA_SW_NUMBER_OF_ITEMS+1];
 
     QCBORDecode_EnterMap(decode_context, NULL);
-    return_value = get_and_reset_error(decode_context);
+    return_value = ctoken_get_and_reset_cbor_error(decode_context);
     if(return_value != CTOKEN_ERR_SUCCESS) {
         goto Done2;
     }
@@ -356,7 +356,7 @@ decode_psa_sw_component(QCBORDecodeContext               *decode_context,
     list[CTOKEN_PSA_SW_MEASUREMENT_DESC_FLAG+1].uLabelType  = QCBOR_TYPE_NONE;
 
     QCBORDecode_GetItemsInMap(decode_context, list);
-    return_value = get_and_reset_error(decode_context);
+    return_value = ctoken_get_and_reset_cbor_error(decode_context);
     if(return_value != CTOKEN_ERR_SUCCESS) {
         goto Done;
     }

--- a/src/ctoken_decode_psa.c
+++ b/src/ctoken_decode_psa.c
@@ -437,9 +437,10 @@ ctoken_decode_psa_sw_component(struct ctoken_decode_ctx         *me,
         goto Done;
     }
 
-    return_value = ctoken_decode_enter_array(me,
+    ctoken_decode_enter_array(me,
                                              CTOKEN_PSA_LABEL_SW_COMPONENTS,
                                              &decode_context);
+    return_value = ctoken_decode_get_and_reset_error(me);
     if(return_value == CTOKEN_ERR_CLAIM_NOT_PRESENT) {
         if(no_sw_components == false) {
             return_value = CTOKEN_ERR_SW_COMPONENTS_PRESENCE;

--- a/test/cwt_test.c
+++ b/test/cwt_test.c
@@ -77,7 +77,8 @@ int32_t cwt_test()
     /* Pass in the token and have it validated. If the token was corrupt
      * or the signature check failed, it will be returned here
      */
-    result = ctoken_decode_validate_token(&decode_context, completed_token);
+    ctoken_decode_validate_token(&decode_context, completed_token);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return 300 + (int32_t)result;
     }
@@ -488,7 +489,8 @@ int32_t cwt_tags_test()
                            test->top_level_tag,
                            test->protection_type);
 
-        result = ctoken_decode_validate_token(&decode_context, test->token_to_decode);
+        ctoken_decode_validate_token(&decode_context, test->token_to_decode);
+        result = ctoken_decode_get_and_reset_error(&decode_context);
 
         if(result != test->expected_error) {
             return test_result_code(5, test->test_number, result);

--- a/test/cwt_test.c
+++ b/test/cwt_test.c
@@ -83,7 +83,8 @@ int32_t cwt_test()
     }
 
     /* Get the expiration and see that it is what was expected */
-    result = ctoken_decode_expiration(&decode_context, &expiration);
+    ctoken_decode_expiration(&decode_context, &expiration);
+    result = ctoken_decode_get_error(&decode_context);
     if(result) {
         return 400 +(int32_t)result;
     }

--- a/test/eat_test.c
+++ b/test/eat_test.c
@@ -219,8 +219,9 @@ int32_t basic_eat_test(void)
     /* zero out to make sure results are tested correctly */
     memset(&location, 0, sizeof(location));
 
-    result = ctoken_decode_location(&decode_context,
+    ctoken_decode_location(&decode_context,
                                         &location);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return 1000 + (int32_t)result;
     }
@@ -1153,7 +1154,8 @@ int32_t location_test()
 
     setup_decode_test(UsefulBuf_FROM_BYTE_ARRAY_LITERAL(bad_location),  out, &decode_context);
 
-    error = ctoken_decode_location(&decode_context, &location);
+    ctoken_decode_location(&decode_context, &location);
+    error = ctoken_decode_get_and_reset_error(&decode_context);
     if(error != CTOKEN_ERR_CBOR_TYPE) {
         return test_result_code(1, 0, error);
     }
@@ -1161,7 +1163,8 @@ int32_t location_test()
 
     setup_decode_test(UsefulBuf_FROM_BYTE_ARRAY_LITERAL(no_location),  out, &decode_context);
 
-    error = ctoken_decode_location(&decode_context, &location);
+    ctoken_decode_location(&decode_context, &location);
+    error = ctoken_decode_get_and_reset_error(&decode_context);
     if(error != CTOKEN_ERR_CLAIM_NOT_PRESENT) {
         return test_result_code(1, 1, error);
     }
@@ -1169,7 +1172,8 @@ int32_t location_test()
 
     setup_decode_test(UsefulBuf_FROM_BYTE_ARRAY_LITERAL(empty_location),  out, &decode_context);
 
-    error = ctoken_decode_location(&decode_context, &location);
+    ctoken_decode_location(&decode_context, &location);
+    error = ctoken_decode_get_and_reset_error(&decode_context);
     if(error != CTOKEN_ERR_CLAIM_FORMAT) {
         return test_result_code(1, 2, error);
     }
@@ -1177,7 +1181,8 @@ int32_t location_test()
 
     setup_decode_test(UsefulBuf_FROM_BYTE_ARRAY_LITERAL(location_not_well_formed),  out, &decode_context);
 
-    error = ctoken_decode_location(&decode_context, &location);
+    ctoken_decode_location(&decode_context, &location);
+    error = ctoken_decode_get_and_reset_error(&decode_context);
     if(error != CTOKEN_ERR_CBOR_NOT_WELL_FORMED) {
         return test_result_code(1, 3, error);
     }
@@ -1255,7 +1260,8 @@ int32_t location_test()
         return test_result_code(3, 0, error);
     }
     memset(&location, 0x44, sizeof(struct ctoken_location_t)); /* initialize to something incorrect */
-    error = ctoken_decode_location(&decode_context, &location);
+    ctoken_decode_location(&decode_context, &location);
+    error = ctoken_decode_get_and_reset_error(&decode_context);
     if(error != CTOKEN_ERR_SUCCESS ||
        !ctoken_location_is_item_present(&location, CTOKEN_EAT_LABEL_LATITUDE) ||
        !ctoken_location_is_item_present(&location, CTOKEN_EAT_LABEL_LONGITUDE) ||
@@ -1798,12 +1804,14 @@ int32_t map_and_array_test()
     if(ctoken_err != CTOKEN_ERR_SUCCESS) {
         return test_result_code(2, 1, ctoken_err);;
     }
-    ctoken_err = ctoken_decode_enter_map(&de, 665, &cbor_de);
+    ctoken_decode_enter_map(&de, 665, &cbor_de);
+    ctoken_err = ctoken_decode_get_and_reset_error(&de);
     if(ctoken_err != CTOKEN_ERR_SUCCESS) {
         return test_result_code(3, 1, ctoken_err);;
     }
     QCBORDecode_GetInt64InMapN(cbor_de, 1, &iii);
-    ctoken_err = ctoken_decode_exit_map(&de);
+    ctoken_decode_exit_map(&de);
+    ctoken_err = ctoken_decode_get_and_reset_error(&de);
     if(ctoken_err != CTOKEN_ERR_SUCCESS) {
          return test_result_code(4, 1, ctoken_err);
      }
@@ -1815,26 +1823,31 @@ int32_t map_and_array_test()
             return test_result_code(5, i, 0);
         }
     }
-    ctoken_err = ctoken_decode_exit_array(&de);
+    ctoken_decode_exit_array(&de);
+    ctoken_err = ctoken_decode_get_and_reset_error(&de);
     if(ctoken_err != CTOKEN_ERR_SUCCESS) {
         return test_result_code(6, 1, ctoken_err);
     }
     /* Completed test decoding the token */
 
     /* Test array not found */
-    ctoken_err = ctoken_decode_enter_array(&de, 45, &cbor_de);
+    ctoken_decode_enter_array(&de, 45, &cbor_de);
+    ctoken_err = ctoken_decode_get_and_reset_error(&de);
+
     if(ctoken_err != CTOKEN_ERR_CLAIM_NOT_PRESENT) {
         return test_result_code(7, 1, ctoken_err);
     }
 
     /* Test map not found */
-    ctoken_err = ctoken_decode_enter_array(&de, 666, &cbor_de);
+    ctoken_decode_enter_array(&de, 666, &cbor_de);
+    ctoken_err = ctoken_decode_get_and_reset_error(&de);
     if(ctoken_err != CTOKEN_ERR_CLAIM_NOT_PRESENT) {
         return test_result_code(8, 1, ctoken_err);
     }
 
     /* Test closing an array that is not open */
-    ctoken_err = ctoken_decode_exit_array(&de);
+    ctoken_decode_exit_array(&de);
+    ctoken_err = ctoken_decode_get_and_reset_error(&de);
     if(ctoken_err != CTOKEN_ERR_CBOR_DECODE) {
         return test_result_code(9, 1, ctoken_err);
     }

--- a/test/eat_test.c
+++ b/test/eat_test.c
@@ -182,7 +182,8 @@ int32_t basic_eat_test(void)
         return 799;
     }
 
-    result = ctoken_decode_security_level(&decode_context, &security_level);
+    ctoken_decode_security_level(&decode_context, &security_level);
+    result = ctoken_decode_get_error(&decode_context);
     if(result) {
         return 800 + (int32_t)result;
     }
@@ -198,7 +199,8 @@ int32_t basic_eat_test(void)
         return 999;
     }
 
-    result = ctoken_decode_debug_state(&decode_context, &debug_level);
+    ctoken_decode_debug_state(&decode_context, &debug_level);
+    result = ctoken_decode_get_error(&decode_context);
     if(result) {
         return 900 + (int32_t)result;
     }
@@ -231,7 +233,8 @@ int32_t basic_eat_test(void)
         return 1299;
     }
 
-    result = ctoken_decode_intended_use(&decode_context, &use);
+    ctoken_decode_intended_use(&decode_context, &use);
+    result = ctoken_decode_get_error(&decode_context);
     if(result) {
         return 1500 + (int32_t)result;
     }
@@ -1350,7 +1353,8 @@ int32_t debug_and_boot_test()
         return 500 + (int32_t)error;
     }
 
-    error = ctoken_decode_debug_state(&decode_context, &debug_state);
+    ctoken_decode_debug_state(&decode_context, &debug_state);
+    error = ctoken_decode_get_error(&decode_context);
     if(error != CTOKEN_ERR_SUCCESS || debug_state != CTOKEN_DEBUG_DISABLED_SINCE_BOOT) {
         return 600 + (int32_t)error;
     }
@@ -1394,15 +1398,17 @@ int32_t debug_and_boot_test()
 
 
     /* --- decode debug state that is wrong type --- */
-    setup_decode_test(UsefulBuf_FROM_BYTE_ARRAY_LITERAL(bad_debug1),  out, &decode_context);
-    error = ctoken_decode_debug_state(&decode_context, &debug_state);
+    setup_decode_test(UsefulBuf_FROM_BYTE_ARRAY_LITERAL(bad_debug1), out, &decode_context);
+    ctoken_decode_debug_state(&decode_context, &debug_state);
+    error = ctoken_decode_get_error(&decode_context);
     if(error != CTOKEN_ERR_CBOR_TYPE) {
         return 1100 + (int32_t)error;
     }
 
     /* --- decode debug state that is not well formed --- */
     setup_decode_test(UsefulBuf_FROM_BYTE_ARRAY_LITERAL(bad_debug2),  out, &decode_context);
-    error = ctoken_decode_debug_state(&decode_context, &debug_state);
+    ctoken_decode_debug_state(&decode_context, &debug_state);
+    error = ctoken_decode_get_error(&decode_context);
     if(error != CTOKEN_ERR_CBOR_NOT_WELL_FORMED) {
         return 1200 + (int32_t)error;
     }
@@ -1410,7 +1416,8 @@ int32_t debug_and_boot_test()
 
     /* --- decode debug state that is not a valid value --- */
     setup_decode_test(UsefulBuf_FROM_BYTE_ARRAY_LITERAL(bad_debug3),  out, &decode_context);
-    error = ctoken_decode_debug_state(&decode_context, &debug_state);
+    ctoken_decode_debug_state(&decode_context, &debug_state);
+    error = ctoken_decode_get_error(&decode_context);
     if(error != CTOKEN_ERR_CLAIM_RANGE) {
         return 1300 + (int32_t)error;
     }

--- a/test/eat_test.c
+++ b/test/eat_test.c
@@ -150,7 +150,8 @@ int32_t basic_eat_test(void)
         return 300 + (int32_t)result;
     }
 
-    result = ctoken_decode_nonce(&decode_context, &nonce);
+    ctoken_decode_nonce(&decode_context, &nonce);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return 400 + (int32_t)result;
     }
@@ -158,7 +159,9 @@ int32_t basic_eat_test(void)
         return 499;
     }
 
-    result = ctoken_decode_ueid(&decode_context, &ueid);
+    ctoken_decode_ueid(&decode_context, &ueid);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
+
     if(result) {
         return 500 + (int32_t)result;
     }
@@ -166,7 +169,9 @@ int32_t basic_eat_test(void)
         return 599;
     }
 
-    result = ctoken_decode_oemid(&decode_context, &oemid);
+    ctoken_decode_oemid(&decode_context, &oemid);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
+
     if(result) {
         return 600 + (int32_t)result;
     }
@@ -174,7 +179,8 @@ int32_t basic_eat_test(void)
         return 699;
     }
 
-    result = ctoken_decode_origination(&decode_context, &origination);
+    ctoken_decode_origination(&decode_context, &origination);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return 700 + (int32_t)result;
     }
@@ -191,7 +197,8 @@ int32_t basic_eat_test(void)
         return 899;
     }
 
-    result = ctoken_decode_secure_boot(&decode_context, &secure_boot);
+    ctoken_decode_secure_boot(&decode_context, &secure_boot);
+    result = ctoken_decode_get_error(&decode_context);
     if(result) {
         return 900 + (int32_t)result;
     }
@@ -225,7 +232,8 @@ int32_t basic_eat_test(void)
     }
 
 
-    result = ctoken_decode_uptime(&decode_context, &uptime);
+    ctoken_decode_uptime(&decode_context, &uptime);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return 1200 + (int32_t)result;
     }
@@ -354,7 +362,9 @@ int32_t submods_test(void)
          return 300 + (int32_t)result;
      }
 
-     result = ctoken_decode_nonce(&decode_context, &nonce);
+     ctoken_decode_nonce(&decode_context, &nonce);
+     result = ctoken_decode_get_and_reset_error(&decode_context);
+
      if(result) {
          return 400 + (int32_t)result;
      }
@@ -364,7 +374,8 @@ int32_t submods_test(void)
 
     ctoken_decode_enter_named_submod(&decode_context, "sub1");
 
-    result = ctoken_decode_ueid(&decode_context, &ueid);
+    ctoken_decode_ueid(&decode_context, &ueid);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return 500 + (int32_t)result;
     }
@@ -402,7 +413,9 @@ int32_t submods_test(void)
         return 540;
     }
 
-    result = ctoken_decode_oemid(&decode_context, &oemid);
+    ctoken_decode_oemid(&decode_context, &oemid);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
+
     if(result) {
         return 600 + (int32_t)result;
     }
@@ -416,7 +429,8 @@ int32_t submods_test(void)
     
 
     /* Get nonce against to know we are back at the top level */
-    result = ctoken_decode_nonce(&decode_context, &nonce);
+    ctoken_decode_nonce(&decode_context, &nonce);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return 400 + (int32_t)result;
     }
@@ -861,7 +875,8 @@ static int32_t one_decode_errors_test_case(const struct decode_submod_test_confi
     }
 
     if(ctoken_result == CTOKEN_ERR_SUCCESS) {
-        ctoken_result = ctoken_decode_nonce(&decode_context, &nonce);
+        ctoken_decode_nonce(&decode_context, &nonce);
+        ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
         if(ctoken_result != t->expected_decode_nonce) {
             return test_result_code(5, t->test_number, ctoken_result);
         }
@@ -969,7 +984,8 @@ int32_t submod_decode_errors_test()
     }
 
     for(nest_level = 0; nest_level < 20; nest_level++) {
-        ctoken_result = ctoken_decode_nonce(&decode_context, &nonce);
+        ctoken_decode_nonce(&decode_context, &nonce);
+        ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
         if(ctoken_result) {
             break;
         }
@@ -1348,7 +1364,8 @@ int32_t debug_and_boot_test()
         return 400 + (int32_t)error;
     }
 
-    error = ctoken_decode_secure_boot(&decode_context, &secure_boot);
+    ctoken_decode_secure_boot(&decode_context, &secure_boot);
+    error = ctoken_decode_get_error(&decode_context);
     if(error != CTOKEN_ERR_SUCCESS || secure_boot != true) {
         return 500 + (int32_t)error;
     }
@@ -1425,7 +1442,8 @@ int32_t debug_and_boot_test()
 
     /* --- decode secure boot that is not a valid value --- */
     setup_decode_test(UsefulBuf_FROM_BYTE_ARRAY_LITERAL(bad_secure_boot1),  out, &decode_context);
-    error = ctoken_decode_secure_boot(&decode_context, &secure_boot);
+    ctoken_decode_secure_boot(&decode_context, &secure_boot);
+    error = ctoken_decode_get_error(&decode_context);
     if(error != CTOKEN_ERR_CBOR_TYPE) {
         return 1400 + (int32_t)error;
     }
@@ -1433,7 +1451,8 @@ int32_t debug_and_boot_test()
 
     /* --- decode secure boot that is not well formed --- */
     setup_decode_test(UsefulBuf_FROM_BYTE_ARRAY_LITERAL(bad_secure_boot2),  out, &decode_context);
-    error = ctoken_decode_secure_boot(&decode_context, &secure_boot);
+    ctoken_decode_secure_boot(&decode_context, &secure_boot);
+    error = ctoken_decode_get_error(&decode_context);
     /* Only check for fail as QCBOR error codes for getting bool needs work */
     if(error == CTOKEN_ERR_SUCCESS) {
         return 1500 + (int32_t)error;
@@ -1653,7 +1672,8 @@ int32_t secboot_test(void)
         return test_result_code(1, 0, result);;
     }
 
-    result = ctoken_decode_secure_boot(&decode_context, &sec_boot);
+    ctoken_decode_secure_boot(&decode_context, &sec_boot);
+    result = ctoken_decode_get_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS || sec_boot != true) {
         return test_result_code(1, 1, result);
     }
@@ -1664,7 +1684,8 @@ int32_t secboot_test(void)
         return test_result_code(1, 0, result);;
     }
 
-    result = ctoken_decode_secure_boot(&decode_context, &sec_boot);
+    ctoken_decode_secure_boot(&decode_context, &sec_boot);
+    result = ctoken_decode_get_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS || sec_boot != false) {
         return test_result_code(2, 1, result);
     }
@@ -1675,7 +1696,8 @@ int32_t secboot_test(void)
         return test_result_code(3, 0, result);;
     }
 
-    result = ctoken_decode_secure_boot(&decode_context, &sec_boot);
+    ctoken_decode_secure_boot(&decode_context, &sec_boot);
+    result = ctoken_decode_get_error(&decode_context);
     if(result != CTOKEN_ERR_CBOR_TYPE) {
         return test_result_code(2, 1, result);
     }
@@ -1686,7 +1708,8 @@ int32_t secboot_test(void)
         return test_result_code(3, 0, result);;
     }
 
-    result = ctoken_decode_secure_boot(&decode_context, &sec_boot);
+    ctoken_decode_secure_boot(&decode_context, &sec_boot);
+    result = ctoken_decode_get_error(&decode_context);
     if(result != CTOKEN_ERR_CBOR_TYPE) {
         return test_result_code(2, 1, result);
     }
@@ -1696,7 +1719,8 @@ int32_t secboot_test(void)
         return test_result_code(3, 0, result);;
     }
 
-    result = ctoken_decode_secure_boot(&decode_context, &sec_boot);
+    ctoken_decode_secure_boot(&decode_context, &sec_boot);
+    result = ctoken_decode_get_error(&decode_context);
     if(result != CTOKEN_ERR_CBOR_NOT_WELL_FORMED) {
         return test_result_code(2, 1, result);
     }
@@ -1707,7 +1731,8 @@ int32_t secboot_test(void)
         return test_result_code(3, 0, result);;
     }
 
-    result = ctoken_decode_secure_boot(&decode_context, &sec_boot);
+    ctoken_decode_secure_boot(&decode_context, &sec_boot);
+    result = ctoken_decode_get_error(&decode_context);
     if(result != CTOKEN_ERR_CBOR_TYPE) {
         return test_result_code(2, 1, result);
     }
@@ -1717,7 +1742,8 @@ int32_t secboot_test(void)
         return test_result_code(3, 0, result);;
     }
 
-    result = ctoken_decode_secure_boot(&decode_context, &sec_boot);
+    ctoken_decode_secure_boot(&decode_context, &sec_boot);
+    result = ctoken_decode_get_error(&decode_context);
     if(result != CTOKEN_ERR_CBOR_TYPE) {
         return test_result_code(2, 1, result);
     }
@@ -1906,11 +1932,13 @@ int32_t profile_decode_test(void)
         return test_result_code(1, 0, result);;
     }
 
-    result = ctoken_decode_profile_uri(&decode_context, &profile);
+    ctoken_decode_profile_uri(&decode_context, &profile);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS) {
         return test_result_code(1, 1, result);
     }
-    result = ctoken_decode_profile_oid(&decode_context, &profile);
+    ctoken_decode_profile_oid(&decode_context, &profile);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_CBOR_TYPE) {
         return test_result_code(1, 2, result);
     }
@@ -1920,11 +1948,13 @@ int32_t profile_decode_test(void)
         return test_result_code(2, 1, result);;
     }
 
-    result = ctoken_decode_profile_oid(&decode_context, &profile);
+    ctoken_decode_profile_oid(&decode_context, &profile);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS) {
         return test_result_code(2, 2, result);
     }
-    result = ctoken_decode_profile_uri(&decode_context, &profile);
+    ctoken_decode_profile_uri(&decode_context, &profile);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_CBOR_TYPE) {
         return test_result_code(2, 3, result);
     }
@@ -1935,12 +1965,14 @@ int32_t profile_decode_test(void)
         return test_result_code(3, 0, result);;
     }
 
-    result = ctoken_decode_profile_oid(&decode_context, &profile);
+    ctoken_decode_profile_oid(&decode_context, &profile);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_CBOR_TYPE) {
         return test_result_code(3, 1, result);
     }
 
-    result = ctoken_decode_profile_uri(&decode_context, &profile);
+    ctoken_decode_profile_uri(&decode_context, &profile);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_CBOR_TYPE) {
         return test_result_code(3, 2, result);
     }
@@ -1951,12 +1983,14 @@ int32_t profile_decode_test(void)
         return test_result_code(4, 0, result);;
     }
 
-    result = ctoken_decode_profile_oid(&decode_context, &profile);
+    ctoken_decode_profile_oid(&decode_context, &profile);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_CBOR_NOT_WELL_FORMED) {
         return test_result_code(4, 1, result);
     }
 
-    result = ctoken_decode_profile_uri(&decode_context, &profile);
+    ctoken_decode_profile_uri(&decode_context, &profile);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_CBOR_NOT_WELL_FORMED) {
         return test_result_code(4, 2, result);
     }
@@ -1968,12 +2002,14 @@ int32_t profile_decode_test(void)
         return test_result_code(5, 0, result);;
     }
 
-    result = ctoken_decode_profile_oid(&decode_context, &profile);
+    ctoken_decode_profile_oid(&decode_context, &profile);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_DUPLICATE_LABEL) {
         return test_result_code(5, 1, result);
     }
 
-    result = ctoken_decode_profile_uri(&decode_context, &profile);
+    ctoken_decode_profile_uri(&decode_context, &profile);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_DUPLICATE_LABEL) {
         return test_result_code(5, 2, result);
     }
@@ -2051,7 +2087,8 @@ int32_t basic_types_decode_test(void)
         return test_result_code(1, 0, result);;
     }
 
-    result = ctoken_decode_bool(&decode_context, 22, &b);
+    ctoken_decode_bool(&decode_context, 22, &b);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS) {
         return test_result_code(1, 1, result);
     }
@@ -2064,7 +2101,8 @@ int32_t basic_types_decode_test(void)
         return test_result_code(2, 0, result);;
     }
 
-    result = ctoken_decode_double(&decode_context, 22, &d);
+    ctoken_decode_double(&decode_context, 22, &d);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS) {
         return test_result_code(2, 1, result);
     }

--- a/test/eat_test.c
+++ b/test/eat_test.c
@@ -145,7 +145,8 @@ int32_t basic_eat_test(void)
     /* Pass in the token and have it validated. If the token was corrupt
      * or the signature check failed, it will be returned here
      */
-    result = ctoken_decode_validate_token(&decode_context, completed_token);
+    ctoken_decode_validate_token(&decode_context, completed_token);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return 300 + (int32_t)result;
     }
@@ -360,7 +361,8 @@ int32_t submods_test(void)
                         CTOKEN_PROTECTION_BY_TAG,
                         0);
 
-     result = ctoken_decode_validate_token(&decode_context, completed_token);
+    ctoken_decode_validate_token(&decode_context, completed_token);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
      if(result) {
          return 300 + (int32_t)result;
      }
@@ -861,7 +863,8 @@ static int32_t one_decode_errors_test_case(const struct decode_submod_test_confi
                        0,
                        CTOKEN_PROTECTION_NONE);
 
-    ctoken_result = ctoken_decode_validate_token(&decode_context, t->token);
+    ctoken_decode_validate_token(&decode_context, t->token);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result) {
         return test_result_code(1, t->test_number, ctoken_result);
     }
@@ -999,7 +1002,8 @@ int32_t submod_decode_errors_test()
                        0,
                        CTOKEN_PROTECTION_NONE);
 
-    ctoken_result = ctoken_decode_validate_token(&decode_context, TEST2UB(submods_valid_deeply_nested));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(submods_valid_deeply_nested));
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result) {
         return test_result_code(20, 0, ctoken_result);
     }
@@ -1036,7 +1040,8 @@ int32_t submod_decode_errors_test()
 
 
     /* Try calling exit without entering */
-    ctoken_result = ctoken_decode_validate_token(&decode_context, TEST2UB(submods_valid_deeply_nested));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(submods_valid_deeply_nested));
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result) {
         return test_result_code(25, 0, ctoken_result);
     }
@@ -1048,7 +1053,8 @@ int32_t submod_decode_errors_test()
 
 
     /* Trigger an unusual error ctoken_decode_exit_submod */
-    ctoken_result = ctoken_decode_validate_token(&decode_context, TEST2UB(submods_valid_deeply_nested));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(submods_valid_deeply_nested));
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result) {
         return test_result_code(25, 0, ctoken_result);
     }
@@ -1098,7 +1104,8 @@ static int32_t setup_decode_test(struct q_useful_buf_c     cbor_input,
                        CTOKEN_PROTECTION_BY_TAG,
                        0);
 
-     ctoken_result = ctoken_decode_validate_token(decode_context, completed_token);
+    ctoken_decode_validate_token(decode_context, completed_token);
+    ctoken_result = ctoken_decode_get_and_reset_error(decode_context);
      if(ctoken_result) {
          return 1;
      }
@@ -1282,7 +1289,8 @@ int32_t location_test()
                        CTOKEN_PROTECTION_BY_TAG,
                        0);
 
-    error = ctoken_decode_validate_token(&decode_context, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(expected_full_location));
+    ctoken_decode_validate_token(&decode_context, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(expected_full_location));
+    error = ctoken_decode_get_and_reset_error(&decode_context);
     if(error) {
         return test_result_code(3, 0, error);
     }
@@ -1392,7 +1400,8 @@ int32_t debug_and_boot_test()
                        T_COSE_OPT_ALLOW_SHORT_CIRCUIT,
                        CTOKEN_PROTECTION_BY_TAG,
                        0);
-    error = ctoken_decode_validate_token(&decode_context, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(expected_boot_and_debug));
+    ctoken_decode_validate_token(&decode_context, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(expected_boot_and_debug));
+    error = ctoken_decode_get_and_reset_error(&decode_context);
     if(error != CTOKEN_ERR_SUCCESS) {
         return 400 + (int32_t)error;
     }
@@ -1550,13 +1559,15 @@ int32_t get_next_test()
                        0,
                        CTOKEN_PROTECTION_NONE);
 
-    result = ctoken_decode_validate_token(&decode_context,
+    ctoken_decode_validate_token(&decode_context,
                                  Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(submods_uccs));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return test_result_code(1, 0, result);;
     }
 
-    result = ctoken_decode_next_claim(&decode_context, &claim);
+    ctoken_decode_next_claim(&decode_context, &claim);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS ||
        claim.uLabelType != QCBOR_TYPE_INT64 ||
        claim.label.int64 != 10 ||
@@ -1565,7 +1576,8 @@ int32_t get_next_test()
         return test_result_code(2, 0, result);
     }
 
-    result = ctoken_decode_next_claim(&decode_context, &claim);
+    ctoken_decode_next_claim(&decode_context, &claim);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS ||
        claim.uLabelType != QCBOR_TYPE_INT64 ||
        claim.label.int64 != 11 ||
@@ -1573,7 +1585,8 @@ int32_t get_next_test()
         return test_result_code(3, 0, result);
     }
 
-    result = ctoken_decode_next_claim(&decode_context, &claim);
+    ctoken_decode_next_claim(&decode_context, &claim);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS ||
        claim.uLabelType != QCBOR_TYPE_INT64 ||
        claim.label.int64 != 15 ||
@@ -1581,7 +1594,8 @@ int32_t get_next_test()
         return test_result_code(4, 0, result);
     }
 
-    result = ctoken_decode_next_claim(&decode_context, &claim);
+    ctoken_decode_next_claim(&decode_context, &claim);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS ||
        claim.uLabelType != QCBOR_TYPE_INT64 ||
        claim.label.int64 != 16 ||
@@ -1590,7 +1604,8 @@ int32_t get_next_test()
         return test_result_code(5, 0, result);
     }
 
-    result = ctoken_decode_next_claim(&decode_context, &claim);
+    ctoken_decode_next_claim(&decode_context, &claim);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS ||
        claim.uLabelType != QCBOR_TYPE_INT64 ||
        claim.label.int64 != 6 ||
@@ -1599,7 +1614,8 @@ int32_t get_next_test()
         return test_result_code(6, 0, result);
     }
 
-    result = ctoken_decode_next_claim(&decode_context, &claim);
+    ctoken_decode_next_claim(&decode_context, &claim);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS ||
        claim.uLabelType != QCBOR_TYPE_INT64 ||
        claim.label.int64 != 14 ||
@@ -1608,7 +1624,8 @@ int32_t get_next_test()
         return test_result_code(7, 0, result);
     }
 
-    result = ctoken_decode_next_claim(&decode_context, &claim);
+    ctoken_decode_next_claim(&decode_context, &claim);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_NO_MORE_CLAIMS) {
         return test_result_code(8, 0, result);
     }
@@ -1630,7 +1647,8 @@ int32_t get_next_test()
         return test_result_code(110, 0, 0);
     }
 
-    result = ctoken_decode_next_claim(&decode_context, &claim);
+    ctoken_decode_next_claim(&decode_context, &claim);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS ||
        claim.uLabelType != QCBOR_TYPE_INT64 ||
        claim.label.int64 != 14 ||
@@ -1639,7 +1657,8 @@ int32_t get_next_test()
         return test_result_code(11, 0, result);
     }
 
-    result = ctoken_decode_next_claim(&decode_context, &claim);
+    ctoken_decode_next_claim(&decode_context, &claim);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_NO_MORE_CLAIMS) {
         return test_result_code(12, 0, result);
     }
@@ -1667,7 +1686,8 @@ int32_t get_next_test()
          return test_result_code(111, 0, 0);
      }
 
-    result = ctoken_decode_next_claim(&decode_context, &claim);
+    ctoken_decode_next_claim(&decode_context, &claim);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS ||
        claim.uLabelType != QCBOR_TYPE_INT64 ||
        claim.label.int64 != 14 ||
@@ -1676,7 +1696,8 @@ int32_t get_next_test()
         return test_result_code(17, 0, result);
     }
 
-    result = ctoken_decode_next_claim(&decode_context, &claim);
+    ctoken_decode_next_claim(&decode_context, &claim);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_NO_MORE_CLAIMS) {
         return test_result_code(18, 0, result);
     }
@@ -1687,7 +1708,8 @@ int32_t get_next_test()
           return test_result_code(19, 0, result);
     }
 
-    result = ctoken_decode_next_claim(&decode_context, &claim);
+    ctoken_decode_next_claim(&decode_context, &claim);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_NO_MORE_CLAIMS) {
         return test_result_code(20, 0, result);
     }
@@ -1707,7 +1729,8 @@ int32_t secboot_test(void)
                        0,
                        CTOKEN_PROTECTION_NONE);
 
-    result = ctoken_decode_validate_token(&decode_context, TEST2UB(secboot_valid1));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(secboot_valid1));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return test_result_code(1, 0, result);;
     }
@@ -1719,7 +1742,8 @@ int32_t secboot_test(void)
     }
 
 
-    result = ctoken_decode_validate_token(&decode_context, TEST2UB(secboot_valid2));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(secboot_valid2));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return test_result_code(1, 0, result);;
     }
@@ -1731,7 +1755,8 @@ int32_t secboot_test(void)
     }
 
 
-    result = ctoken_decode_validate_token(&decode_context, TEST2UB(secboot_invalid1));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(secboot_invalid1));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return test_result_code(3, 0, result);;
     }
@@ -1743,7 +1768,8 @@ int32_t secboot_test(void)
     }
 
 
-    result = ctoken_decode_validate_token(&decode_context, TEST2UB(secboot_invalid2));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(secboot_invalid2));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return test_result_code(3, 0, result);;
     }
@@ -1754,7 +1780,8 @@ int32_t secboot_test(void)
         return test_result_code(2, 1, result);
     }
 
-    result = ctoken_decode_validate_token(&decode_context, TEST2UB(secboot_invalid3));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(secboot_invalid3));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return test_result_code(3, 0, result);;
     }
@@ -1766,7 +1793,8 @@ int32_t secboot_test(void)
     }
 
 
-    result = ctoken_decode_validate_token(&decode_context, TEST2UB(secboot_invalid4));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(secboot_invalid4));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return test_result_code(3, 0, result);;
     }
@@ -1777,7 +1805,8 @@ int32_t secboot_test(void)
         return test_result_code(2, 1, result);
     }
 
-    result = ctoken_decode_validate_token(&decode_context, TEST2UB(secboot_invalid5));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(secboot_invalid5));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return test_result_code(3, 0, result);;
     }
@@ -1834,7 +1863,8 @@ int32_t map_and_array_test()
 
     /* Decode the token just made */
     ctoken_decode_init(&de, 0, 0, CTOKEN_PROTECTION_NONE);
-    ctoken_err = ctoken_decode_validate_token(&de, completed_token);
+    ctoken_decode_validate_token(&de, completed_token);
+    ctoken_err = ctoken_decode_get_and_reset_error(&de);
     if(ctoken_err != CTOKEN_ERR_SUCCESS) {
         return test_result_code(2, 1, ctoken_err);;
     }
@@ -1974,7 +2004,8 @@ int32_t profile_decode_test(void)
                        0,
                        CTOKEN_PROTECTION_NONE);
 
-    result = ctoken_decode_validate_token(&decode_context, TEST2UB(profile_valid_uri));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(profile_valid_uri));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return test_result_code(1, 0, result);;
     }
@@ -1990,7 +2021,8 @@ int32_t profile_decode_test(void)
         return test_result_code(1, 2, result);
     }
 
-    result = ctoken_decode_validate_token(&decode_context, TEST2UB(profile_valid_oid));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(profile_valid_oid));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return test_result_code(2, 1, result);;
     }
@@ -2007,7 +2039,8 @@ int32_t profile_decode_test(void)
     }
 
 
-    result = ctoken_decode_validate_token(&decode_context, TEST2UB(profile_invalid_type));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(profile_invalid_type));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS) {
         return test_result_code(3, 0, result);;
     }
@@ -2025,7 +2058,8 @@ int32_t profile_decode_test(void)
     }
 
 
-    result = ctoken_decode_validate_token(&decode_context, TEST2UB(profile_invalid_nwf));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(profile_invalid_nwf));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS) {
         return test_result_code(4, 0, result);;
     }
@@ -2044,7 +2078,8 @@ int32_t profile_decode_test(void)
 
 
 
-    result = ctoken_decode_validate_token(&decode_context, TEST2UB(profile_invalid_dup));
+    ctoken_decode_validate_token(&decode_context, TEST2UB(profile_invalid_dup));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS) {
         return test_result_code(5, 0, result);;
     }
@@ -2129,7 +2164,8 @@ int32_t basic_types_decode_test(void)
                        0,
                        CTOKEN_PROTECTION_NONE);
 
-    result = ctoken_decode_validate_token(&decode_context, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(valid_bool));
+    ctoken_decode_validate_token(&decode_context, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(valid_bool));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return test_result_code(1, 0, result);;
     }
@@ -2143,7 +2179,8 @@ int32_t basic_types_decode_test(void)
         return test_result_code(1, 2, 0);
     }
 
-    result = ctoken_decode_validate_token(&decode_context, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(valid_double));
+    ctoken_decode_validate_token(&decode_context, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(valid_double));
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return test_result_code(2, 0, result);;
     }

--- a/test/eat_test.c
+++ b/test/eat_test.c
@@ -252,7 +252,8 @@ int32_t basic_eat_test(void)
     }
 
     struct q_useful_buf_c submod_name;
-    result = ctoken_decode_enter_nth_submod(&decode_context, 0, &submod_name);
+    ctoken_decode_enter_nth_submod(&decode_context, 0, &submod_name);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return 1300 + (uint32_t)result;
     }
@@ -262,7 +263,8 @@ int32_t basic_eat_test(void)
         return 1399;
     }
 
-    result = ctoken_decode_exit_submod(&decode_context);
+    ctoken_decode_exit_submod(&decode_context);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return 1400 + (uint32_t)result;
     }
@@ -384,22 +386,25 @@ int32_t submods_test(void)
         return 599;
     }
 
-    ctoken_result = ctoken_decode_get_named_nested_token(&decode_context,
+    ctoken_decode_get_named_nested_token(&decode_context,
                                                          Q_USEFUL_BUF_FROM_SZ_LITERAL("json"),
                                                          &type,
                                                          &submod_token);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result != CTOKEN_ERR_SUCCESS ||
        ub_compare_sz("{ \"ueid\", \"xyz\"}", submod_token) ||
        type != CTOKEN_TYPE_JSON) {
         return 550;
     }
 
-    ctoken_result = ctoken_decode_enter_named_submod(&decode_context, "json");
+    ctoken_decode_enter_named_submod(&decode_context, "json");
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result != CTOKEN_ERR_SUBMOD_IS_A_TOKEN) {
         return 555;
     }
 
-    ctoken_result = ctoken_decode_enter_nth_submod(&decode_context, 0, &submod_name);
+    ctoken_decode_enter_nth_submod(&decode_context, 0, &submod_name);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result != CTOKEN_ERR_SUBMOD_IS_A_TOKEN) {
         return 556;
     }
@@ -861,7 +866,8 @@ static int32_t one_decode_errors_test_case(const struct decode_submod_test_confi
         return test_result_code(1, t->test_number, ctoken_result);
     }
 
-    ctoken_result = ctoken_decode_get_num_submods(&decode_context, &num_submods);
+    ctoken_decode_get_num_submods(&decode_context, &num_submods);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result != t->expected_call_num_submods) {
         return test_result_code(2, t->test_number, ctoken_result);
     }
@@ -870,7 +876,8 @@ static int32_t one_decode_errors_test_case(const struct decode_submod_test_confi
         return test_result_code(3, t->test_number, ctoken_result);
     }
 
-    ctoken_result = ctoken_decode_enter_nth_submod(&decode_context, 0, &name);
+    ctoken_decode_enter_nth_submod(&decode_context, 0, &name);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result != t->expected_enter_0th) {
         return test_result_code(4, t->test_number, ctoken_result);
     }
@@ -882,64 +889,77 @@ static int32_t one_decode_errors_test_case(const struct decode_submod_test_confi
             return test_result_code(5, t->test_number, ctoken_result);
         }
 
-        ctoken_result = ctoken_decode_exit_submod(&decode_context);
+        ctoken_decode_exit_submod(&decode_context);
+        ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
         if(ctoken_result != t->expected_exit_0th) {
             return test_result_code(6, t->test_number, ctoken_result);
         }
     }
 
-    ctoken_result = ctoken_decode_get_nth_nested_token(&decode_context, 0, &nested_token_type, &name, &token);
+    ctoken_decode_get_nth_nested_token(&decode_context, 0, &nested_token_type, &name, &token);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result != t->expected_nested_0th) {
         return test_result_code(7, t->test_number, ctoken_result);
     }
 
-    ctoken_result = ctoken_decode_enter_named_submod(&decode_context, "submod");
+    ctoken_decode_enter_named_submod(&decode_context, "submod");
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result != t->expected_enter_named) {
         return test_result_code(8, t->test_number, ctoken_result);
     }
 
     if(ctoken_result == CTOKEN_ERR_SUCCESS) {
-        ctoken_result = ctoken_decode_exit_submod(&decode_context);
+        ctoken_decode_exit_submod(&decode_context);
+        ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
         if(ctoken_result != t->expected_exit_named) {
             return test_result_code(9, t->test_number, ctoken_result);
         }
     }
 
-    ctoken_result = ctoken_decode_get_named_nested_token(&decode_context,
+    ctoken_decode_get_named_nested_token(&decode_context,
                                                          Q_USEFUL_BUF_FROM_SZ_LITERAL("nested"),
                                                          &nested_token_type,
                                                          &token);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result != t->expected_named_nested) {
         return test_result_code(10, t->test_number, ctoken_result);
     }
 
-    ctoken_result = ctoken_decode_enter_nth_submod(&decode_context, 1, &name);
+    ctoken_decode_enter_nth_submod(&decode_context, 1, &name);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result != t->expected_enter_1st) {
         return test_result_code(11, t->test_number, ctoken_result);
     }
 
     if(ctoken_result == CTOKEN_ERR_SUCCESS) {
-        ctoken_result = ctoken_decode_exit_submod(&decode_context);
+        ctoken_decode_exit_submod(&decode_context);
+        ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
+
         if(ctoken_result != t->expected_exit_1st) {
             return test_result_code(12, t->test_number, ctoken_result);
         }
     }
 
-    ctoken_result = ctoken_decode_get_nth_nested_token(&decode_context, 1, &nested_token_type, &name, &token);
+    ctoken_decode_get_nth_nested_token(&decode_context, 1, &nested_token_type, &name, &token);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result != t->expected_nested_1st) {
         return test_result_code(13, t->test_number, ctoken_result);
     }
 
-    ctoken_result = ctoken_decode_enter_nth_submod(&decode_context, 2, &name);
+    ctoken_decode_enter_nth_submod(&decode_context, 2, &name);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result != t->expected_enter_2nd) {
         return test_result_code(14, t->test_number, ctoken_result);
     }
     if(ctoken_result == CTOKEN_ERR_SUCCESS) {
-        ctoken_result = ctoken_decode_exit_submod(&decode_context);
+        ctoken_decode_exit_submod(&decode_context);
+        ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
+
         /* Don't bother with error check here */
     }
 
-    ctoken_result = ctoken_decode_get_nth_nested_token(&decode_context, 2, &nested_token_type, &name, &token);
+    ctoken_decode_get_nth_nested_token(&decode_context, 2, &nested_token_type, &name, &token);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result != t->expected_nested_2nd) {
         return test_result_code(15, t->test_number, ctoken_result);
     }
@@ -995,17 +1015,20 @@ int32_t submod_decode_errors_test()
             return test_result_code(21, nest_level, 0);
         }
 
-        ctoken_result = ctoken_decode_get_num_submods(&decode_context, &num);
+        ctoken_decode_get_num_submods(&decode_context, &num);
+        ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
         if(num == 0) {
             break;
         }
 
-        ctoken_result = ctoken_decode_get_nth_nested_token(&decode_context, 1, &type, &name, &token);
+        ctoken_decode_get_nth_nested_token(&decode_context, 1, &type, &name, &token);
+        ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
         if(ctoken_result) {
             return test_result_code(22, nest_level, ctoken_result);
         }
 
-        ctoken_result = ctoken_decode_enter_nth_submod(&decode_context, 0, &name);
+        ctoken_decode_enter_nth_submod(&decode_context, 0, &name);
+        ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
         if(ctoken_result) {
             return test_result_code(23, nest_level, ctoken_result);
         }
@@ -1017,7 +1040,8 @@ int32_t submod_decode_errors_test()
     if(ctoken_result) {
         return test_result_code(25, 0, ctoken_result);
     }
-    ctoken_result = ctoken_decode_exit_submod(&decode_context);
+    ctoken_decode_exit_submod(&decode_context);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result != CTOKEN_ERR_NO_SUBMOD_OPEN) {
         return test_result_code(25, 0, ctoken_result);
     }
@@ -1028,7 +1052,9 @@ int32_t submod_decode_errors_test()
     if(ctoken_result) {
         return test_result_code(25, 0, ctoken_result);
     }
-    ctoken_result = ctoken_decode_enter_nth_submod(&decode_context, 0, &name);
+    ctoken_decode_enter_nth_submod(&decode_context, 0, &name);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
+
     /* Exit map prematurely to cause error condition inside
      * ctoken_decode_exit_submod(). These three all succeed and undo
      * entry into the submod, the submod section and the UCCS.
@@ -1037,7 +1063,8 @@ int32_t submod_decode_errors_test()
     QCBORDecode_ExitMap(&(decode_context.qcbor_decode_context));
     QCBORDecode_ExitMap(&(decode_context.qcbor_decode_context));
 
-    ctoken_result = ctoken_decode_exit_submod(&decode_context);
+    ctoken_decode_exit_submod(&decode_context);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result != CTOKEN_ERR_CBOR_DECODE) {
         return test_result_code(25, 0, ctoken_result);
     }
@@ -1586,13 +1613,15 @@ int32_t get_next_test()
         return test_result_code(8, 0, result);
     }
 
-    result = ctoken_decode_get_num_submods(&decode_context, &num_sub_mods);
+    ctoken_decode_get_num_submods(&decode_context, &num_sub_mods);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS ||
        num_sub_mods != 3) {
        return test_result_code(9, 0, result);
     }
 
-    result = ctoken_decode_enter_nth_submod(&decode_context, 0, &submod_name);
+    ctoken_decode_enter_nth_submod(&decode_context, 0, &submod_name);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS) {
         return test_result_code(10, 0, result);
     }
@@ -1615,17 +1644,21 @@ int32_t get_next_test()
         return test_result_code(12, 0, result);
     }
 
-    result = ctoken_decode_exit_submod(&decode_context);
+    ctoken_decode_exit_submod(&decode_context);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
+
     if(result != CTOKEN_ERR_SUCCESS) {
-         return test_result_code(14, 0, result);
-     }
+        return test_result_code(14, 0, result);
+    }
 
-     result = ctoken_decode_enter_nth_submod(&decode_context, 1, &submod_name);
-     if(result != CTOKEN_ERR_SUBMOD_IS_A_TOKEN) {
-         return test_result_code(15, 0, result);
-     }
+    ctoken_decode_enter_nth_submod(&decode_context, 1, &submod_name);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
+    if(result != CTOKEN_ERR_SUBMOD_IS_A_TOKEN) {
+        return test_result_code(15, 0, result);
+    }
 
-    result = ctoken_decode_enter_nth_submod(&decode_context, 2, &submod_name);
+    ctoken_decode_enter_nth_submod(&decode_context, 2, &submod_name);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS) {
         return test_result_code(16, 0, result);
     }
@@ -1648,7 +1681,8 @@ int32_t get_next_test()
         return test_result_code(18, 0, result);
     }
 
-    result = ctoken_decode_exit_submod(&decode_context);
+    ctoken_decode_exit_submod(&decode_context);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result != CTOKEN_ERR_SUCCESS) {
           return test_result_code(19, 0, result);
     }

--- a/test/psa_test.c
+++ b/test/psa_test.c
@@ -101,7 +101,8 @@ int32_t psa_basic_test()
     /* Pass in the token and have it validated. If the token was corrupt
      * or the signature check failed, it will be returned here
      */
-    result = ctoken_decode_validate_token(&decode_context, completed_token);
+    ctoken_decode_validate_token(&decode_context, completed_token);
+    result = ctoken_decode_get_and_reset_error(&decode_context);
     if(result) {
         return 300 + (int32_t)result;
     }
@@ -297,7 +298,8 @@ static int32_t one_swc_decode_test_case(const struct decode_swc_test_config *t)
                        0,
                        CTOKEN_PROTECTION_NONE);
 
-    ctoken_result = ctoken_decode_validate_token(&decode_context, t->token);
+    ctoken_decode_validate_token(&decode_context, t->token);
+    ctoken_result = ctoken_decode_get_and_reset_error(&decode_context);
     if(ctoken_result) {
         return test_result_code(1, t->test_number, ctoken_result);
     }


### PR DESCRIPTION
Move to a last-error strategy similar to QCBOR for error handling

This is NOT a backwards compatible change.